### PR TITLE
Added project setup file, compatible with MacOS, Linux, and Windows

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -33,10 +33,10 @@ elif [[ "$OSTYPE" == "msys" || "$OSTYPE" == "win32" ]]; then
     #docker-compose up -d database
     # Start Python backend
     cd Backend
-    start cmd /c "python3 server.py"
+    start python server.py
     # Start React frontend
     cd ../Frontend
-    start cmd /c "npm run start"
+    start npm run start
 else
     echo "Unsupported operating system"
     exit 1

--- a/setup.sh
+++ b/setup.sh
@@ -1,14 +1,9 @@
 #!/bin/bash
 
-# Detect the user's operating system
+# Detecting the user's operating system
 if [[ "$OSTYPE" == "linux-gnu"* ]]; then
     # Linux detected
     echo "Detected Linux OS" 
-    # Run appropriate commands for Linux
-
-    # Start Docker database
-    #docker-compose up -d database
-
     # Start Python backend
     cd Backend
     python server.py &
@@ -19,11 +14,6 @@ if [[ "$OSTYPE" == "linux-gnu"* ]]; then
 elif [[ "$OSTYPE" == "darwin"* ]]; then
     # macOS detected 
     echo "Detected macOS"
-    # Run appropriate commands for macOS
-
-    # Start Docker database
-    #docker-compose up -d database
-
     # Start Python backend
     cd Backend
     python server.py &
@@ -34,11 +24,6 @@ elif [[ "$OSTYPE" == "darwin"* ]]; then
 elif [[ "$OSTYPE" == "msys" || "$OSTYPE" == "win32" ]]; then
     # Windows detected
     echo "Detected Windows OS"
-    # Run appropriate commands for Windows
-
-    # Start Docker database
-    #docker-compose up -d database
-    
     # Start Python backend
     cd Backend
     start python server.py

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+# Detect the user's operating system
+if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+    # Linux detected
+    echo "Detected Linux OS" 
+    # Run appropriate commands for Linux
+    # Start Docker database
+    #docker-compose up -d database
+    # Start Python backend
+    cd Backend
+    python server.py &
+    # Start React frontend
+    cd ../Frontend
+    npm run start
+elif [[ "$OSTYPE" == "darwin"* ]]; then
+    # macOS detected 
+    echo "Detected macOS"
+    # Run appropriate commands for macOS
+    # Start Docker database
+    #docker-compose up -d database
+    # Start Python backend
+    cd Backend
+    python server.py &
+    # Start React frontend
+    cd ../Frontend
+    npm run start
+elif [[ "$OSTYPE" == "msys" || "$OSTYPE" == "win32" ]]; then
+    # Windows detected
+    echo "Detected Windows OS"
+    # Run appropriate commands for Windows
+    # Start Docker database
+    #docker-compose up -d database
+    # Start Python backend
+    cd Backend
+    start cmd /c "python3 server.py"
+    # Start React frontend
+    cd ../Frontend
+    start cmd /c "npm run start"
+else
+    echo "Unsupported operating system"
+    exit 1
+fi

--- a/setup.sh
+++ b/setup.sh
@@ -36,6 +36,7 @@ elif [[ "$OSTYPE" == "msys" || "$OSTYPE" == "win32" ]]; then
     start python server.py
     # Start React frontend
     cd ../Frontend
+    start npm install
     start npm run start
 else
     echo "Unsupported operating system"

--- a/setup.sh
+++ b/setup.sh
@@ -5,36 +5,44 @@ if [[ "$OSTYPE" == "linux-gnu"* ]]; then
     # Linux detected
     echo "Detected Linux OS" 
     # Run appropriate commands for Linux
+
     # Start Docker database
     #docker-compose up -d database
+
     # Start Python backend
     cd Backend
     python server.py &
-    # Start React frontend
+    # Start React frontend and install dependencies 
     cd ../Frontend
+    npm install
     npm run start
 elif [[ "$OSTYPE" == "darwin"* ]]; then
     # macOS detected 
     echo "Detected macOS"
     # Run appropriate commands for macOS
+
     # Start Docker database
     #docker-compose up -d database
+
     # Start Python backend
     cd Backend
     python server.py &
-    # Start React frontend
+    # Start React frontend and install dependencies 
     cd ../Frontend
+    npm install
     npm run start
 elif [[ "$OSTYPE" == "msys" || "$OSTYPE" == "win32" ]]; then
     # Windows detected
     echo "Detected Windows OS"
     # Run appropriate commands for Windows
+
     # Start Docker database
     #docker-compose up -d database
+    
     # Start Python backend
     cd Backend
     start python server.py
-    # Start React frontend
+    # Start React frontend and install dependencies 
     cd ../Frontend
     start npm install
     start npm run start


### PR DESCRIPTION
**Issue:** 
Currently, all project setup must be done manually when the project is first cloned from Github. This involves installing all dependencies, starting the python backend and then starting the react frontend. The goal of this issue is to compress these steps into one executable file that can be ran from the command line on any system utilizing Linux, Windows, or MacOS. 

**Changes:** 
A setup file setup.sh has been pushed to the root directory, and was pushed with executable permissions such that the file will be executable when pulled. The file correctly detects and echoes the user's operating system, installs all dependencies, and launches both the backend and frontend. To run the file, on Windows navigate to the root directory of the project and in a command prompt or PowerShell run './setup.sh'. If using Linux or MacOS, use a bash terminal to navigate to the root directory of the project and run 'bash setup.sh'

Running the setup file from a freshly cloned repository has been verified to work correctly on Windows, MacOS, and Linux provided that python and NPM are installed on the machine with relevant path variables added. 