### PR TITLE
Implementing Field of Definition Filters

### DIFF
--- a/Backend/PostgresConnector.py
+++ b/Backend/PostgresConnector.py
@@ -13,7 +13,6 @@ class PostgresConnector:
                 "dbname=dynamSystems user=postgres password=docker")
 
 
-
     def getAllSystems(self):
         columns = '*'
         sql = "SELECT " + columns + " FROM public.data"
@@ -59,8 +58,6 @@ class PostgresConnector:
         return result
 
 
-
-
     def buildWhereText(self, filters):
         # remove empty filters
         for filter in filters.copy():
@@ -87,4 +84,3 @@ class PostgresConnector:
 
         filterText += " AND ".join(conditions)
         return filterText
-

--- a/Backend/PostgresConnector.py
+++ b/Backend/PostgresConnector.py
@@ -52,7 +52,7 @@ class PostgresConnector:
         labels = "(" + ", ".join(["'" + str(item) + "'" for item in labels]) + ")"
         columns = '*'
         sql = "SELECT " + columns + " FROM public.data WHERE label in " + labels
-        cur = connection.cursor()
+        cur = self.connection.cursor()
         cur.execute(sql)
         result = cur.fetchall()
         cur.close

--- a/Backend/PostgresConnector.py
+++ b/Backend/PostgresConnector.py
@@ -59,24 +59,32 @@ class PostgresConnector:
         return result
 
 
-# function that builds the WHERE part of SQL query to filter the results
-    def buildWhereText(self,filters):
-    # remove empty filters
+
+
+    def buildWhereText(self, filters):
+        # remove empty filters
         for filter in filters.copy():
-            if filters[filter] == []:
+            if not filters[filter] or filters[filter] == []:
                 del filters[filter]
 
         if len(filters) == 0:
             return ""
 
         filterText = " WHERE "
+        conditions = []
 
-    # go through each non-empty filter and add it to the list for the WHERE clause
-        for index, filter in enumerate(filters):
-            filterText += filter + " in " + \
-                    "(" + ', '.join(str(e) for e in filters[filter]) + ")"
+        if 'base_field_degree' in filters:
+            # CASTING ERROR, for some reason base_field degree is being evaluated as boolean, even though it has the
+            # same formating as the other integer query fields like degree. TO FIX before merge
+            conditions.append("CAST(base_field_degree AS integer) IN (" + str(filters['base_field_degree']) + ")")
 
-            if (index != len(filters)-1):
-                filterText += " AND "
+        if 'base_field_label' in filters:
+            conditions.append("base_field_label LIKE '%" + filters['base_field_label'] + "%'")
 
+        for filter, values in filters.items():
+            if filter not in ['base_field_degree', 'base_field_label']:
+                conditions.append(filter + " IN (" + ', '.join(str(e) for e in values) + ")")
+
+        filterText += " AND ".join(conditions)
         return filterText
+

--- a/Frontend/src/pages/ExploreSystems.js
+++ b/Frontend/src/pages/ExploreSystems.js
@@ -237,7 +237,7 @@ function ExploreSystems({ width }) {
                                 <li><span className="caret" onClick={toggleTree}>Field of Definition</span>
                                     <ul className="nested">
                                     <input 
-                                        type="text" 
+                                        type="number" 
                                         style={textBoxStyle} 
                                         onChange={(event) => replaceFilter('base_field_degree', event.target.value)}
                                     />

--- a/Frontend/src/pages/ExploreSystems.js
+++ b/Frontend/src/pages/ExploreSystems.js
@@ -16,7 +16,9 @@ function ExploreSystems({ width }) {
         is_Chebyshev:  [],
         is_Newton:  [],
         customDegree: "",
-        customDimension: ""
+        customDimension: "",
+        base_field_label: "",
+        base_field_degree: ""
     });
 
     const [systems, setSystems] = useState(null);
@@ -234,12 +236,20 @@ function ExploreSystems({ width }) {
                             <ul id="myUL">
                                 <li><span className="caret" onClick={toggleTree}>Field of Definition</span>
                                     <ul className="nested">
-                                        <input type="text" style={textBoxStyle} />
-                                        <label>Degree</label>
-                                        <br />
-                                        <input type="text" style={textBoxStyle} />
-                                        <label>Label</label>
-                                        <br />
+                                    <input 
+                                        type="text" 
+                                        style={textBoxStyle} 
+                                        onChange={(event) => replaceFilter('base_field_degree', event.target.value)}
+                                    />
+                                    <label>Degree</label>
+                                    <br />
+                                    <input 
+                                        type="text" 
+                                        style={textBoxStyle} 
+                                        onChange={(event) => replaceFilter('base_field_label', event.target.value)}
+                                    />
+                                    <label>Label</label>
+                                    <br />
                                     </ul>
                                 </li>
                             </ul>

--- a/Frontend/src/pages/ExploreSystems.js
+++ b/Frontend/src/pages/ExploreSystems.js
@@ -81,7 +81,9 @@ function ExploreSystems({ width }) {
                     is_polynomial: filters.is_polynomial,
                     is_Lattes: filters.is_Lattes,
                     is_Chebyshev: filters.is_Chebyshev,
-                    is_Newton: filters.is_Newton
+                    is_Newton: filters.is_Newton,
+                    base_field_label: filters.base_field_label,
+                    base_field_degree: filters.base_field_degree
                 }
             )
             setSystems(result.data);


### PR DESCRIPTION
**Issue:** 
Previously, the 2 filters available  (Degree and Label) under the Field of Definition dropdown tab of the filters section were just placeholder textboxes that did not store any input or pass any inputs into a query to return filtered systems. 

**Code changes:** 
- Updated ExploreSystems.js in the frontend to collect an input from the text boxes
- Changed the Field of Definition Degree textbox in ExploreSystems.js to only accept integers, strings would cause errors/return nothing
- Added fields for Field of Definition Degree and Label to the collected and returned filters json objects in ExploreSystems.js
- Updated buildWhereText method in the backend file PostgresConnector.py to handle string case for Field of Definition Label (format for this parameter is "x.x.x.x" where x is an integer value)

**Steps to replicate changes:** 

1. Clone issue branch
2. Run setup file or start servers by method of your choosing 
3. Select Field of Definition dropdown from filters
4. Input integers into the degree field, and labels in the form of "x.x.x.x" where x is an integer, to check returned systems

*NOTE given incomplete state of current database, all current systems have field of definition degree 1 and label 1.1.1.1, however correctness of filter implementation can still be checked by inputting any other value to these fields which should return no systems. I performed further validation to check that these filters have the correct formatting in the whereText, filters json object, and final SQL text using breakpoints and selective print statements, but these have been since removed to keep the codebase clean. 

**Screenshots:** 

No results shown when degree =/= 1: 
![1](https://github.com/oss-slu/dads/assets/126357831/7f75e268-9b03-443a-b6bb-095d29764f53)

No results shown when label =/= 1.1.1.1: 
![2](https://github.com/oss-slu/dads/assets/126357831/c9248ba8-dd09-48ad-9860-b9b1c664a035)

Results shown when degree = 1: 
![3](https://github.com/oss-slu/dads/assets/126357831/a14e13bf-f905-4519-a30c-a010fd080d64)

Results shown when label = 1.1.1.1: 
![4](https://github.com/oss-slu/dads/assets/126357831/fbc59a2a-4cd5-4561-83d7-92098671d998)

Works in combination with other filters: 
![5](https://github.com/oss-slu/dads/assets/126357831/51626f1b-f1e5-4517-9149-f0953e768812)

