### PR TITLE
Implemented Automorphism Group Cardinality Filter

### DIFF
--- a/Backend/PostgresConnector.py
+++ b/Backend/PostgresConnector.py
@@ -81,8 +81,11 @@ class PostgresConnector:
         if 'base_field_label' in filters:
             conditions.append("base_field_label LIKE '%" + filters['base_field_label'] + "%'")
 
+        if 'automorphism_group_cardinality' in filters:
+            conditions.append("CAST(automorphism_group_cardinality AS integer) IN (" + str(filters['automorphism_group_cardinality']) + ")")
+
         for filter, values in filters.items():
-            if filter not in ['base_field_degree', 'base_field_label']:
+            if filter not in ['base_field_degree', 'base_field_label', 'automorphism_group_cardinality']:
                 conditions.append(filter + " IN (" + ', '.join(str(e) for e in values) + ")")
 
         filterText += " AND ".join(conditions)

--- a/Backend/PostgresConnector.py
+++ b/Backend/PostgresConnector.py
@@ -10,7 +10,10 @@ class PostgresConnector:
 
     def __init__(self):
         self.connection = psycopg2.connect(
-                "dbname=dynamSystems user=postgres password=docker")
+                host="localhost",
+                dbname="dynamSystems",
+                user="postgres",
+                password="docker")
 
 
 

--- a/Backend/PostgresConnector.py
+++ b/Backend/PostgresConnector.py
@@ -52,7 +52,7 @@ class PostgresConnector:
         labels = "(" + ", ".join(["'" + str(item) + "'" for item in labels]) + ")"
         columns = '*'
         sql = "SELECT " + columns + " FROM public.data WHERE label in " + labels
-        cur = connection.cursor()
+        cur = self.connection.cursor()
         cur.execute(sql)
         result = cur.fetchall()
         cur.close
@@ -63,7 +63,7 @@ class PostgresConnector:
     def buildWhereText(self,filters):
     # remove empty filters
         for filter in filters.copy():
-            if filters[filter] == []:
+            if not filters[filters] or filters[filter] == []:
                 del filters[filter]
 
         if len(filters) == 0:

--- a/Backend/PostgresConnector.py
+++ b/Backend/PostgresConnector.py
@@ -66,7 +66,7 @@ class PostgresConnector:
     def buildWhereText(self,filters):
     # remove empty filters
         for filter in filters.copy():
-            if not filters[filters] or filters[filter] == []:
+            if filters[filter] == []:
                 del filters[filter]
 
         if len(filters) == 0:

--- a/Frontend/src/pages/ExploreSystems.js
+++ b/Frontend/src/pages/ExploreSystems.js
@@ -17,7 +17,7 @@ function ExploreSystems({ width }) {
         is_Newton:  [],
         customDegree: "",
         customDimension: "",
-	automorphism_Cardinality: "",	
+	automorphism_group_cardinality: [],	
     });
 
     const [systems, setSystems] = useState(null);
@@ -81,7 +81,7 @@ function ExploreSystems({ width }) {
                     is_Lattes: filters.is_Lattes,
                     is_Chebyshev: filters.is_Chebyshev,
                     is_Newton: filters.is_Newton,
-		    automorphism_Cardinality: filters.automorphism_Cardinality
+		    automorphism_group_cardinality: filters.automorphism_group_cardinality
                 }
             )
             setSystems(result.data);
@@ -269,6 +269,10 @@ function ExploreSystems({ width }) {
                             <ul id="myUL">
                                 <li><span className="caret" onClick={toggleTree}>Automorphism Group</span>
                                     <ul className="nested">
+	    				<input type="number" style={textBoxStyle} onChange={(event) => replaceFilter('automorphism_group_cardinality', event.target.value)} />
+	    				<label>Cardinality</label>
+	    				<br />
+
                                     </ul>
                                 </li>
                             </ul>
@@ -379,12 +383,6 @@ function ExploreSystems({ width }) {
                                 <li><span className="caret" onClick={toggleTree}>Average #Aut</span>
                                     <input type="text" style={{ float: "right", ...textBoxStyle }} />
                                     <ul className="nested">
-	    				// hey Jelliss, this is where you should implement the inputs
-	    				<input type="number" style={textBoxStyle} 
-	    					onChange={(event) => replaceFilter('automorphism_Cardinality', event.target.value)} />
-	    				<label>Cardinality </label>
-	    				<br />
-	    				// this is going to be where matrice filter will be implemented, however, need to figure out what kind of input
 	    			    </ul>
                                 </li>
                             </ul>

--- a/Frontend/src/pages/ExploreSystems.js
+++ b/Frontend/src/pages/ExploreSystems.js
@@ -84,7 +84,7 @@ function ExploreSystems({ width }) {
                     is_Lattes: filters.is_Lattes,
                     is_Chebyshev: filters.is_Chebyshev,
                     is_Newton: filters.is_Newton,
-		    automorphism_group_cardinality: filters.automorphism_group_cardinality,
+		    automorphism_group_cardinality: Number(filters.automorphism_group_cardinality),
                     base_field_label: filters.base_field_label,
                     base_field_degree: filters.base_field_degree
                 }

--- a/Frontend/src/pages/ExploreSystems.js
+++ b/Frontend/src/pages/ExploreSystems.js
@@ -17,7 +17,7 @@ function ExploreSystems({ width }) {
         is_Newton:  [],
         customDegree: "",
         customDimension: "",
-	      automorphism_group_cardinality: [],
+	automorphism_group_cardinality: [],
         base_field_label: "",
         base_field_degree: ""
 
@@ -84,7 +84,7 @@ function ExploreSystems({ width }) {
                     is_Lattes: filters.is_Lattes,
                     is_Chebyshev: filters.is_Chebyshev,
                     is_Newton: filters.is_Newton,
-		                automorphism_group_cardinality: filters.automorphism_group_cardinality,
+		    automorphism_group_cardinality: filters.automorphism_group_cardinality,
                     base_field_label: filters.base_field_label,
                     base_field_degree: filters.base_field_degree
                 }

--- a/Frontend/src/pages/ExploreSystems.js
+++ b/Frontend/src/pages/ExploreSystems.js
@@ -16,7 +16,8 @@ function ExploreSystems({ width }) {
         is_Chebyshev:  [],
         is_Newton:  [],
         customDegree: "",
-        customDimension: ""
+        customDimension: "",
+	automorphism_Cardinality: "",	
     });
 
     const [systems, setSystems] = useState(null);
@@ -79,7 +80,8 @@ function ExploreSystems({ width }) {
                     is_polynomial: filters.is_polynomial,
                     is_Lattes: filters.is_Lattes,
                     is_Chebyshev: filters.is_Chebyshev,
-                    is_Newton: filters.is_Newton
+                    is_Newton: filters.is_Newton,
+		    automorphism_Cardinality: filters.automorphism_Cardinality
                 }
             )
             setSystems(result.data);
@@ -377,7 +379,13 @@ function ExploreSystems({ width }) {
                                 <li><span className="caret" onClick={toggleTree}>Average #Aut</span>
                                     <input type="text" style={{ float: "right", ...textBoxStyle }} />
                                     <ul className="nested">
-                                    </ul>
+	    				// hey Jelliss, this is where you should implement the inputs
+	    				<input type="number" style={textBoxStyle} 
+	    					onChange={(event) => replaceFilter('automorphism_Cardinality', event.target.value)} />
+	    				<label>Cardinality </label>
+	    				<br />
+	    				// this is going to be where matrice filter will be implemented, however, need to figure out what kind of input
+	    			    </ul>
                                 </li>
                             </ul>
 


### PR DESCRIPTION
Issue: 
originally there was no option for input under automorphism group filter on the UI, and the filter was not implemented to be used.

Changes:
there is now a number based input box called cardinality in the automorphism group caret tree, and this can filter the data on when the input is changed only with the up and down buttons. if the input is edited manually and set to empty, the connector will breakdown, this must be looked into further.

*NOTE do not manually change the value, use the up and down arrow buttons to set the input, manually setting the input to empty will break the connector.

filter set to 0
![Screenshot from 2023-10-23 14-08-53](https://github.com/oss-slu/dads/assets/144739653/89cfc569-b5e4-4efc-9fc8-dac556db7ef1)

filter set to 1
![Screenshot from 2023-10-23 14-09-12](https://github.com/oss-slu/dads/assets/144739653/e8ebc272-824e-4836-83f3-5669bc1c716e)

filter set to 2
![Screenshot from 2023-10-23 14-09-18](https://github.com/oss-slu/dads/assets/144739653/c2c9601e-41ad-44a3-ac20-30a2d0e7f1da)


