### PR TITLE
WIP on issue #67

### DIFF
--- a/Backend/PostgresConnector.py
+++ b/Backend/PostgresConnector.py
@@ -77,7 +77,7 @@ class PostgresConnector:
             conditions.append("CAST(base_field_degree AS integer) IN (" + str(filters['base_field_degree']) + ")")
             
         if 'indeterminacy_locus_dimension' in filters:
-            conditions.append("CAST(indeterminacy_locus_dimension AS integer) IN (" + int(filters['indeterminacy_locus_dimension']) + ")")
+            conditions.append("CAST(indeterminacy_locus_dimension AS integer) IN (" + str(filters['indeterminacy_locus_dimension']) + ")")
 
 
         if 'base_field_label' in filters:

--- a/Backend/PostgresConnector.py
+++ b/Backend/PostgresConnector.py
@@ -57,8 +57,9 @@ class PostgresConnector:
         cur.close
         return result
 
-
     def buildWhereText(self, filters):
+        # TESTING, REMOVE:
+        print(filters)
         # remove empty filters
         for filter in filters.copy():
             if not filters[filter] or filters[filter] == []:
@@ -74,12 +75,16 @@ class PostgresConnector:
             # CASTING ERROR, for some reason base_field degree is being evaluated as boolean, even though it has the
             # same formating as the other integer query fields like degree. TO FIX before merge
             conditions.append("CAST(base_field_degree AS integer) IN (" + str(filters['base_field_degree']) + ")")
+            
+        if 'indeterminacy_locus_dimension' in filters:
+            conditions.append("CAST(indeterminacy_locus_dimension AS integer) IN (" + int(filters['indeterminacy_locus_dimension']) + ")")
+
 
         if 'base_field_label' in filters:
             conditions.append("base_field_label LIKE '%" + filters['base_field_label'] + "%'")
 
         for filter, values in filters.items():
-            if filter not in ['base_field_degree', 'base_field_label']:
+            if filter not in ['base_field_degree', 'base_field_label', 'indeterminacy_locus_dimension']:
                 conditions.append(filter + " IN (" + ', '.join(str(e) for e in values) + ")")
 
         filterText += " AND ".join(conditions)

--- a/Frontend/src/pages/ExploreSystems.js
+++ b/Frontend/src/pages/ExploreSystems.js
@@ -20,7 +20,8 @@ function ExploreSystems({ width }) {
         customDegree: "",
         customDimension: "",
         base_field_label: "",
-        base_field_degree: ""
+        base_field_degree: "",
+        indeterminacy_locus_dimension: ""
     });
 
     const [systems, setSystems] = useState(null);
@@ -85,7 +86,8 @@ function ExploreSystems({ width }) {
                     is_Chebyshev: filters.is_Chebyshev,
                     is_Newton: filters.is_Newton,
                     base_field_label: filters.base_field_label,
-                    base_field_degree: filters.base_field_degree
+                    base_field_degree: filters.base_field_degree,
+                    indeterminacy_locus_dimension: filters.indeterminacy_locus_dimension
                 }
                 
             )
@@ -298,6 +300,12 @@ function ExploreSystems({ width }) {
                             <ul id="myUL">
                                 <li><span className="caret" onClick={toggleTree}>Indeterminacy Locus</span>
                                     <ul className="nested">
+                                    <input 
+                                        type="number" 
+                                        style={textBoxStyle} 
+                                        onChange={(event) => replaceFilter('indeterminacy_locus_dimension', event.target.value)}
+                                    />
+                                    <label>Dimension</label>
                                     </ul>
                                 </li>
                             </ul>


### PR DESCRIPTION
**Issue:**

Previously, the Indeterminacy Locus dropdown tab of the filters section was not functional and had no input boxes to add filters, specifically it was missing a dimension filter. 

**Code changes:**

Updated ExploreSystems.js in the frontend to collect an input from a number type textbox labeled "Dimension"
Added a field for indeterminacy locus dimension to the collected and returned filters json objects in ExploreSystems.js
Updated buildWhereText method in the backend file PostgresConnector.py to handle new filter

**Steps to replicate changes:**

Clone issue branch
Run setup file or start servers by method of your choosing
Select Indeterminacy Locus dropdown from filters
Input integers into the dimension field
-1 should return all results, as all current systems in the test data have a -1 dimension. 
Any other value should return no results. 

**Screenshots:**

**No results shown when dimension =/= -1:**
![pr1](https://github.com/oss-slu/dads/assets/126357831/393ea2b8-47e8-45a5-b187-c50aaf28c844)

![pr2](https://github.com/oss-slu/dads/assets/126357831/615e048d-5bda-499a-81dc-2baf90c7e1ca)

**Results shown when degree = -1:**
![pr3](https://github.com/oss-slu/dads/assets/126357831/0fac7c9a-012c-4bf9-be84-3ef4446c2366)

**Works in combination with other filters:**
![pr4](https://github.com/oss-slu/dads/assets/126357831/820f0c6a-efa7-4783-80fd-259262d3685f)