### PR TITLE
get filters button implemented, buildWhereText scaled

### DIFF
--- a/Backend/PostgresConnector.py
+++ b/Backend/PostgresConnector.py
@@ -16,7 +16,6 @@ class PostgresConnector:
                 user="postgres",
                 password="docker")
 
-
     def getAllSystems(self):
         columns = '*'
         sql = "SELECT " + columns + " FROM public.data"
@@ -26,8 +25,7 @@ class PostgresConnector:
         cur.close()
         return result
 
-
-# gets a system identified by its label, input is string
+    # gets a system identified by its label, input is string
     def getSystem(self,label):
         columns = '*'
         sql = "SELECT " + columns + " FROM public.data WHERE label = '" + label + "'"
@@ -37,8 +35,7 @@ class PostgresConnector:
         cur.close()
         return result
 
-
-# gets systems that match the passed in filters, input should be json object
+    # gets systems that match the passed in filters, input should be json object
     def getFilteredSystems(self,filters):
         columns = 'label, N, degree, models_original_polys_val, base_field_latex'
         whereText = self.buildWhereText(filters)
@@ -49,8 +46,7 @@ class PostgresConnector:
         cur.close()
         return result
 
-
-# gets a subset of the systems identified by the labels, input should be json list
+    # gets a subset of the systems identified by the labels, input should be json list
     def getSelectedSystems(self,labels):
         labels = "(" + ", ".join(["'" + str(item) + "'" for item in labels]) + ")"
         columns = '*'
@@ -60,7 +56,6 @@ class PostgresConnector:
         result = cur.fetchall()
         cur.close
         return result
-
 
     def buildWhereText(self, filters):
         # remove empty filters
@@ -74,19 +69,14 @@ class PostgresConnector:
         filterText = " WHERE "
         conditions = []
 
-        if 'base_field_degree' in filters:
-            # CASTING ERROR, for some reason base_field degree is being evaluated as boolean, even though it has the
-            # same formating as the other integer query fields like degree. TO FIX before merge
-            conditions.append("CAST(base_field_degree AS integer) IN (" + str(filters['base_field_degree']) + ")")
-
-        if 'base_field_label' in filters:
-            conditions.append("base_field_label LIKE '%" + filters['base_field_label'] + "%'")
-
-        if 'automorphism_group_cardinality' in filters:
-            conditions.append("CAST(automorphism_group_cardinality AS integer) IN (" + str(filters['automorphism_group_cardinality']) + ")")
-
         for filter, values in filters.items():
-            if filter not in ['base_field_degree', 'base_field_label', 'automorphism_group_cardinality']:
+            if filter in ['base_field_degree', 'automorphism_group_cardinality']:
+                conditions.append("CAST(" + filter + " AS integer) IN (" + values + ")")
+
+            elif filter in ['base_field_label']:
+                conditions.append(filter + " LIKE '%" + values + "%'")
+
+            else:
                 conditions.append(filter + " IN (" + ', '.join(str(e) for e in values) + ")")
 
         filterText += " AND ".join(conditions)

--- a/Backend/PostgresConnector.py
+++ b/Backend/PostgresConnector.py
@@ -70,7 +70,7 @@ class PostgresConnector:
         conditions = []
 
         for filter, values in filters.items():
-            if filter in ['base_field_degree', 'automorphism_group_cardinality']:
+            if filter in ['base_field_degree', 'automorphism_group_cardinality','indeterminacy_locus_dimension']:
                 conditions.append("CAST(" + filter + " AS integer) IN (" + values + ")")
 
             elif filter in ['base_field_label']:

--- a/Frontend/src/pages/ExploreSystems.js
+++ b/Frontend/src/pages/ExploreSystems.js
@@ -24,6 +24,8 @@ function ExploreSystems({ width }) {
 
     });
 
+	let connectionStatus = true;
+
     const [systems, setSystems] = useState(null);
 
     const downloadCSV = async () => {
@@ -95,14 +97,11 @@ function ExploreSystems({ width }) {
         } catch (error) {
             setSystems(null)
             alert("Error: CANNOT CONNECT TO DATABASE: Make sure Docker is running correctly")
+		connectionStatus = false;
             console.log(error)
         }
     };
 
-    //useEffect(() => {
-    //    fetchFilteredSystems();
-
-    //}, [filters]); //TODO only gets called when removing a filter and not adding it
 
     const toggleTree = (event) => {
         let el = event.target;
@@ -119,15 +118,11 @@ function ExploreSystems({ width }) {
         else {
             setFilters({ ...filters, [filterName]: [] })
         }
-        //setSystems(null)
-        //fetchFilteredSystems();
     }
 
     //used to set a filter property, replacing it with the old value
     const replaceFilter = (filterName, filterValue) => {
         setFilters({ ...filters, [filterName]: filterValue })
-        //setSystems(null)
-        //fetchFilteredSystems();
     }
 
     //used to add to a filter property that can contain multiple values
@@ -141,8 +136,6 @@ function ExploreSystems({ width }) {
         else {
             filters[filterName].push(filterValue)
         }
-        //setSystems(null)
-        //fetchFilteredSystems(); //calling fetch data here probably isn't best practice... might want to fix use effect
     }
 
     const textBoxStyle = {
@@ -344,7 +337,7 @@ function ExploreSystems({ width }) {
                             }
                         />
 
-                        {systems === null ? <p style = {{color: 'red'}}></p>: <></>}
+                        {connectionStatus === false ? <p style = {{color: 'red'}}>DATABASE CONNECTION ERROR</p>: <></>}
                         {systems != null && systems.length === 0 ? <p>No data meets that criteria</p> : <></>}
                     </Grid>
 

--- a/Frontend/src/pages/ExploreSystems.js
+++ b/Frontend/src/pages/ExploreSystems.js
@@ -102,7 +102,11 @@ function ExploreSystems({ width }) {
         }
     };
 
-
+    useEffect(() => {
+        fetchFilteredSystems();
+     
+     }, []); 
+     
     const toggleTree = (event) => {
         let el = event.target;
         el.parentElement.querySelector(".nested").classList.toggle("active");

--- a/Frontend/src/pages/ExploreSystems.js
+++ b/Frontend/src/pages/ExploreSystems.js
@@ -6,8 +6,6 @@ import { Link } from "react-router-dom";
 import { useState, useEffect } from 'react';
 import { getFilteredSystems, getSelectedSystems } from '../api/routes';
 
-
-
 function ExploreSystems({ width }) {
     const [numMaps, setNum] = useState(0);
     const [filters, setFilters] = useState({
@@ -19,15 +17,13 @@ function ExploreSystems({ width }) {
         is_Newton:  [],
         customDegree: "",
         customDimension: "",
-	automorphism_group_cardinality: [],
+	    automorphism_group_cardinality: [],
         base_field_label: "",
         base_field_degree: ""
 
     });
 
     const [systems, setSystems] = useState(null);
-
-
 
     const downloadCSV = async () => {
         let csvSystems = await fetchDataForCSV()
@@ -86,7 +82,7 @@ function ExploreSystems({ width }) {
                     is_Lattes: filters.is_Lattes,
                     is_Chebyshev: filters.is_Chebyshev,
                     is_Newton: filters.is_Newton,
-		    automorphism_group_cardinality: Number(filters.automorphism_group_cardinality),
+		            automorphism_group_cardinality: Number(filters.automorphism_group_cardinality),
                     base_field_label: filters.base_field_label,
                     base_field_degree: filters.base_field_degree
                 }
@@ -101,19 +97,16 @@ function ExploreSystems({ width }) {
         }
     };
 
-
     //useEffect(() => {
     //    fetchFilteredSystems();
 
     //}, [filters]); //TODO only gets called when removing a filter and not adding it
-
 
     const toggleTree = (event) => {
         let el = event.target;
         el.parentElement.querySelector(".nested").classList.toggle("active");
         el.classList.toggle("caret-down");
     }
-
 
     //used to update a boolean filter, filter is [] if false so that it doesn't matter
     //assumes defaulted to false (UNCHECKED)
@@ -150,7 +143,6 @@ function ExploreSystems({ width }) {
         //fetchFilteredSystems(); //calling fetch data here probably isn't best practice... might want to fix use effect
     }
 
-    
     const textBoxStyle = {
         width: "60px",
         marginRight: "12px"
@@ -171,7 +163,6 @@ function ExploreSystems({ width }) {
 	fetchFilteredSystems();
     };
     
-
     return (
         <>
             <div style={{ marginLeft: width }}>
@@ -183,7 +174,6 @@ function ExploreSystems({ width }) {
                         <div style={{ marginLeft: "10px", marginRight: "10px" }}>
                             <p>Filters</p>
                             <Divider />
-
 
                             <ul id="myUL">
                                 <li><span className="caret" onClick={toggleTree}>Dimension</span>
@@ -201,8 +191,6 @@ function ExploreSystems({ width }) {
                                     </ul>
                                 </li>
                             </ul>
-
-
 
                             <ul id="myUL">
                                 <li><span className="caret" onClick={toggleTree}>Degree</span>
@@ -223,8 +211,6 @@ function ExploreSystems({ width }) {
                                     </ul>
                                 </li>
                             </ul>
-
-
 
                             <ul id="myUL">
                                 <li><span className="caret" onClick={toggleTree}>Class</span>
@@ -302,10 +288,9 @@ function ExploreSystems({ width }) {
                             <ul id="myUL">
                                 <li><span className="caret" onClick={toggleTree}>Automorphism Group</span>
                                     <ul className="nested">
-	    				<input type="number" style={textBoxStyle} onChange={(event) => replaceFilter('automorphism_group_cardinality', event.target.value)} />
-	    				<label>Cardinality</label>
-	    				<br />
-
+	    				                <input type="number" style={textBoxStyle} onChange={(event) => replaceFilter('automorphism_group_cardinality', event.target.value)} />
+	    				                <label>Cardinality</label>
+	    				                <br />
                                     </ul>
                                 </li>
                             </ul>
@@ -324,15 +309,14 @@ function ExploreSystems({ width }) {
                                 </li>
                             </ul>
 	    			
-	    		    <ul id="myUL">
-	    			<li><button style={buttonStyle} onClick={sendFilters}>Get Results</button>
-	    			</li>
-	    		    </ul>
+	    		            <ul id="myUL">
+	    			            <li><button style={buttonStyle} onClick={sendFilters}>Get Results</button>
+	    			            </li>
+	    		            </ul>
                             <br />
 
                         </div>
                     </Grid>
-
 
                     <Grid className="results-table" item xs={6} >
                         <span style={{ float: "right", color: "red", cursor: 'pointer' }} onClick={() => downloadCSV()}>Download</span>
@@ -356,20 +340,15 @@ function ExploreSystems({ width }) {
                         {systems != null && systems.length === 0 ? <p>No data meets that criteria</p> : <></>}
                     </Grid>
 
-
-
-
                     <Grid className="sidebar" item xs={3}>
                         <div style={{ marginLeft: "10px", marginRight: "10px" }}>
                             <p>Result Statistics </p>
                             <Divider />
+                            
                             <br />
-                           
                             <label>Number of Maps: {numMaps}</label>
-
-
                             <br />
-
+                            
                             <ul id="myUL">
                                 <li><span className="caret" onClick={toggleTree}>Number PCF</span>
                                     <input type="text" style={{ float: "right", ...textBoxStyle }} />
@@ -383,8 +362,6 @@ function ExploreSystems({ width }) {
                                     </ul>
                                 </li>
                             </ul>
-
-
 
                             <ul id="myUL">
                                 <li><span className="caret" onClick={toggleTree}>Average #Periodic</span>
@@ -418,7 +395,7 @@ function ExploreSystems({ width }) {
                                 <li><span className="caret" onClick={toggleTree}>Average #Aut</span>
                                     <input type="text" style={{ float: "right", ...textBoxStyle }} />
                                     <ul className="nested">
-	    			    </ul>
+	    			                </ul>
                                 </li>
                             </ul>
 
@@ -446,22 +423,11 @@ function ExploreSystems({ width }) {
                                     </ul>
                                 </li>
                             </ul>
-
                             <br />
-
                         </div>
                     </Grid>
-
-
                 </div>
-
-
-
-
             </div>
-
-
-
         </>
     )
 }

--- a/Frontend/src/pages/ExploreSystems.js
+++ b/Frontend/src/pages/ExploreSystems.js
@@ -17,7 +17,7 @@ function ExploreSystems({ width }) {
         is_Newton:  [],
         customDegree: "",
         customDimension: "",
-	    automorphism_group_cardinality: [],
+	    automorphism_group_cardinality: "",
         base_field_label: "",
         base_field_degree: ""
 
@@ -82,7 +82,7 @@ function ExploreSystems({ width }) {
                     is_Lattes: filters.is_Lattes,
                     is_Chebyshev: filters.is_Chebyshev,
                     is_Newton: filters.is_Newton,
-		            automorphism_group_cardinality: Number(filters.automorphism_group_cardinality),
+		            automorphism_group_cardinality: filters.automorphism_group_cardinality,
                     base_field_label: filters.base_field_label,
                     base_field_degree: filters.base_field_degree
                 }

--- a/Frontend/src/pages/ExploreSystems.js
+++ b/Frontend/src/pages/ExploreSystems.js
@@ -19,7 +19,8 @@ function ExploreSystems({ width }) {
         customDimension: "",
 	    automorphism_group_cardinality: "",
         base_field_label: "",
-        base_field_degree: ""
+        base_field_degree: "",
+        indeterminacy_locus_dimension: ""
 
     });
 
@@ -84,7 +85,8 @@ function ExploreSystems({ width }) {
                     is_Newton: filters.is_Newton,
 		            automorphism_group_cardinality: filters.automorphism_group_cardinality,
                     base_field_label: filters.base_field_label,
-                    base_field_degree: filters.base_field_degree
+                    base_field_degree: filters.base_field_degree,
+                    indeterminacy_locus_dimension: filters.indeterminacy_locus_dimension
                 }
                 
             )
@@ -305,6 +307,12 @@ function ExploreSystems({ width }) {
                             <ul id="myUL">
                                 <li><span className="caret" onClick={toggleTree}>Indeterminacy Locus</span>
                                     <ul className="nested">
+                                    <input 
+                                        type="number" 
+                                        style={textBoxStyle} 
+                                        onChange={(event) => replaceFilter('indeterminacy_locus_dimension', event.target.value)}
+                                    />
+                                    <label>Dimension</label>
                                     </ul>
                                 </li>
                             </ul>

--- a/Frontend/src/pages/ExploreSystems.js
+++ b/Frontend/src/pages/ExploreSystems.js
@@ -7,9 +7,6 @@ import { useState, useEffect } from 'react';
 import { getFilteredSystems, getSelectedSystems } from '../api/routes';
 
 
-function sendFilters() {
-	alert('this button is working');
-}
 
 function ExploreSystems({ width }) {
     const [numMaps, setNum] = useState(0);
@@ -105,10 +102,10 @@ function ExploreSystems({ width }) {
     };
 
 
-    useEffect(() => {
-        fetchFilteredSystems();
+    //useEffect(() => {
+    //    fetchFilteredSystems();
 
-    }, [filters]); //TODO only gets called when removing a filter and not adding it
+    //}, [filters]); //TODO only gets called when removing a filter and not adding it
 
 
     const toggleTree = (event) => {
@@ -127,15 +124,15 @@ function ExploreSystems({ width }) {
         else {
             setFilters({ ...filters, [filterName]: [] })
         }
-        setSystems(null)
-        fetchFilteredSystems();
+        //setSystems(null)
+        //fetchFilteredSystems();
     }
 
     //used to set a filter property, replacing it with the old value
     const replaceFilter = (filterName, filterValue) => {
         setFilters({ ...filters, [filterName]: filterValue })
-        setSystems(null)
-        fetchFilteredSystems();
+        //setSystems(null)
+        //fetchFilteredSystems();
     }
 
     //used to add to a filter property that can contain multiple values
@@ -149,8 +146,8 @@ function ExploreSystems({ width }) {
         else {
             filters[filterName].push(filterValue)
         }
-        setSystems(null)
-        fetchFilteredSystems(); //calling fetch data here probably isn't best practice... might want to fix use effect
+        //setSystems(null)
+        //fetchFilteredSystems(); //calling fetch data here probably isn't best practice... might want to fix use effect
     }
 
     
@@ -159,6 +156,10 @@ function ExploreSystems({ width }) {
         marginRight: "12px"
     }
 
+    const sendFilters = () => {
+	setSystems(null);
+	fetchFilteredSystems();
+    };
     
 
     return (

--- a/Frontend/src/pages/ExploreSystems.js
+++ b/Frontend/src/pages/ExploreSystems.js
@@ -7,6 +7,9 @@ import { useState, useEffect } from 'react';
 import { getFilteredSystems, getSelectedSystems } from '../api/routes';
 
 
+function sendFilters() {
+	alert('this button is working');
+}
 
 function ExploreSystems({ width }) {
     const [numMaps, setNum] = useState(0);
@@ -155,6 +158,7 @@ function ExploreSystems({ width }) {
         width: "60px",
         marginRight: "12px"
     }
+
     
 
     return (
@@ -308,6 +312,11 @@ function ExploreSystems({ width }) {
                                     </ul>
                                 </li>
                             </ul>
+	    			
+	    		    <ul id="myUL">
+	    			<li><button onClick={sendFilters}>Get Results</button>
+	    			</li>
+	    		    </ul>
                             <br />
 
                         </div>

--- a/Frontend/src/pages/ExploreSystems.js
+++ b/Frontend/src/pages/ExploreSystems.js
@@ -17,7 +17,7 @@ function ExploreSystems({ width }) {
         is_Newton:  [],
         customDegree: "",
         customDimension: "",
-	    automorphism_group_cardinality: "",
+	automorphism_group_cardinality: "",
         base_field_label: "",
         base_field_degree: "",
         indeterminacy_locus_dimension: ""
@@ -344,7 +344,7 @@ function ExploreSystems({ width }) {
                             }
                         />
 
-                        {systems === null ? <p style = {{color: 'red'}}>Unable to connect to database</p>: <></>}
+                        {systems === null ? <p style = {{color: 'red'}}></p>: <></>}
                         {systems != null && systems.length === 0 ? <p>No data meets that criteria</p> : <></>}
                     </Grid>
 

--- a/Frontend/src/pages/ExploreSystems.js
+++ b/Frontend/src/pages/ExploreSystems.js
@@ -155,6 +155,16 @@ function ExploreSystems({ width }) {
         width: "60px",
         marginRight: "12px"
     }
+    
+    const buttonStyle = {
+	border: "none",
+	backgroundColor: "#376dc4",
+	color: "white",
+	cursor: "pointer",
+	fontSize: "15px",
+	padding: "6px 75px",
+	borderRadius: "4px",
+    }
 
     const sendFilters = () => {
 	setSystems(null);
@@ -315,7 +325,7 @@ function ExploreSystems({ width }) {
                             </ul>
 	    			
 	    		    <ul id="myUL">
-	    			<li><button onClick={sendFilters}>Get Results</button>
+	    			<li><button style={buttonStyle} onClick={sendFilters}>Get Results</button>
 	    			</li>
 	    		    </ul>
                             <br />


### PR DESCRIPTION
**Issue:**
1.) Due to filters constantly updating not just on input changes, there was a proneness to missing changes to the filter data structure, glitches that  negated user input, and a possibility for speed issues as we scale up our data.

2.)  the buildWhereText method of the connector was not scalable, and relied on bad coding practices to create conditions for specific filters.

3.) javascript error caused automorphism cardinality filter to interpret 0 as an empty input.

4.) Previously, the Indeterminacy Locus dropdown tab of the filters section was not functional and had no input boxes to add filters, specifically it was missing a dimension filter.


**Code Changes:**
1.)  Button, stylized to fit ui, functions to be the only process that calls the send filters method. Only the button will actually call the filters, not refreshing the page.

2.) buildWhereText method is now scalable for new filters as they are implemented, and follows better coding practices with conditionals and for loops.

3.) error is now solved, ExploreSystems.js now handles the filter as a string instead of an array. 

4.) Updated ExploreSystems.js in the frontend to collect an input from a number type textbox labeled "Dimension"
Added a field for indeterminacy locus dimension to the collected and returned filters json objects in ExploreSystems.js
Updated buildWhereText method in the backend file PostgresConnector.py to handle new filter


**Replicate Changes**
- clone branch
- run setup file.
- upon reaching the explore systems page, press the get filters button to get initial unfiltered results, then apply filters and press button again to see filtered results. 

results on refresh, results after button press empty filters
![Screenshot from 2023-11-06 09-59-21](https://github.com/oss-slu/dads/assets/144739653/efe6fa83-4448-4633-a71c-a81f9a7f4427)
![Screenshot from 2023-11-06 10-02-29](https://github.com/oss-slu/dads/assets/144739653/98f9de10-167c-42d1-b925-5b0e428b3728)



