### PR TITLE
Implemented Postcritically Finite Filters 

### DIFF
--- a/Frontend/src/pages/ExploreSystems.js
+++ b/Frontend/src/pages/ExploreSystems.js
@@ -21,13 +21,13 @@ function ExploreSystems({ width }) {
         is_Lattes: [],
         is_Chebyshev:  [],
         is_Newton:  [],
+        is_pcf: [],
         customDegree: "",
         customDimension: "",
 	    automorphism_group_cardinality: "",
         base_field_label: "",
         base_field_degree: "",
         indeterminacy_locus_dimension: ""
-
     });
 
 	let connectionStatus = true;
@@ -90,6 +90,7 @@ function ExploreSystems({ width }) {
                     is_Lattes: filters.is_Lattes,
                     is_Chebyshev: filters.is_Chebyshev,
                     is_Newton: filters.is_Newton,
+                    is_pcf: filters.is_pcf,
 		            automorphism_group_cardinality: filters.automorphism_group_cardinality,
                     base_field_label: filters.base_field_label,
                     base_field_degree: filters.base_field_degree,
@@ -116,6 +117,7 @@ function ExploreSystems({ width }) {
                 is_Lattes: filters.is_Lattes,
                 is_Chebyshev: filters.is_Chebyshev,
                 is_Newton: filters.is_Newton,
+                is_pcf: filters.is_pcf,
                 automorphism_group_cardinality: filters.automorphism_group_cardinality,
                 base_field_label: filters.base_field_label,
                 base_field_degree: filters.base_field_degree,
@@ -329,6 +331,9 @@ function ExploreSystems({ width }) {
                             <ul id="myUL">
                                 <li><span className="caret" onClick={toggleTree}>Postcritically Finite</span>
                                     <ul className="nested">
+                                        <input type="checkbox" onClick={() => booleanFilter('is_pcf')} />
+                                        <label>Is Postcritically Finite</label>
+                                        <br />
                                     </ul>
                                 </li>
                             </ul>

--- a/Frontend/src/pages/ExploreSystems.js
+++ b/Frontend/src/pages/ExploreSystems.js
@@ -135,10 +135,8 @@ function ExploreSystems({ width }) {
         }
     };
 
-
     useEffect(() => {
         fetchFilteredSystems();
-     
      }, []); 
      
     const toggleTree = (event) => {
@@ -195,7 +193,7 @@ function ExploreSystems({ width }) {
 	setSystems(null);
 	fetchFilteredSystems();
     };
-    
+
     return (
         <>
             <div style={{ marginLeft: width }}>
@@ -329,11 +327,40 @@ function ExploreSystems({ width }) {
                             </ul>
 
                             <ul id="myUL">
-                                <li><span className="caret" onClick={toggleTree}>Postcritically Finite</span>
+                                <li>
+                                    <span className="caret" onClick={toggleTree}>Postcritically Finite</span>
                                     <ul className="nested">
-                                        <input type="checkbox" onClick={() => booleanFilter('is_pcf')} />
-                                        <label>Is Postcritically Finite</label>
-                                        <br />
+                                        <li>
+                                            <input 
+                                                type="radio" 
+                                                id="isPCFTrue"
+                                                name="isPCF" 
+                                                value="true"
+                                                onChange={() => replaceFilter('is_pcf', [true])} 
+                                            />
+                                            <label htmlFor="isPCFTrue">Is Postcritically Finite</label>
+                                        </li>
+                                        <li>
+                                            <input 
+                                                type="radio" 
+                                                id="isPCFFalse"
+                                                name="isPCF" 
+                                                value="false"
+                                                onChange={() => replaceFilter('is_pcf', [false])} 
+                                            />
+                                            <label htmlFor="isPCFFalse">Not Postcritically Finite</label>
+                                        </li>
+                                        <li>
+                                            <input
+                                                type="radio"
+                                                id="showAll"
+                                                name="isPCF"
+                                                value="all"
+                                                onChange={() => replaceFilter('is_pcf', [])}
+                                                defaultChecked
+                                            />
+                                            <label htmlFor="showAll">Show all</label>
+                                        </li>
                                     </ul>
                                 </li>
                             </ul>


### PR DESCRIPTION
**Issue:**

Previously, the Postcritically Finite tab of the filters section was not functional and had no inputs to add filters, specifically it was missing a Boolean filter for is postcritically finite or is not post critically finite.

Desired functionality has been decided to be adding 3 radio buttons to show PCF, show not PCF, and show all (default). 

**Code changes:**

Updated ExploreSystems.js in the frontend to collect an input from one of three radio buttons, labeled "Is postcritically finite", "not postcritically finite", and "show all". 
Added fields in json objects for getting filtered systems and getting result statistics, and to hold the current value for is_pcf along with the other filter values. 

**Steps to replicate changes:**

Clone issue branch
Run setup file or start servers by method of your choosing
Select Postcritically Finite from filters
Check or uncheck various Postcritically Finite radio buttons button
Selecting show all (default) returns 111 results. 
Selecting Is Postcritically Finite returns 3 results.
Selecting Not Postcritically Finite returns 108 results. 

**Screenshots:**
All results shown when show all is selected (default): 
![PR1](https://github.com/oss-slu/dads/assets/126357831/b03d349e-37f4-4116-80f9-6bf9989d452d)
Re-selecting show all after selecting either other radio buttons also still shows all results, screenshot is same as above. 


3 results shown when Is Postcritically Finite is selected: 
![PR2](https://github.com/oss-slu/dads/assets/126357831/95ef79ba-8a48-402e-8c7d-10c162ab961d)


108 results shown when Not Postcritically Finite is selected: 
![PR3](https://github.com/oss-slu/dads/assets/126357831/af79d970-edd0-4b35-bf13-fe28b567cb55)


Works in combination with other filters (Only one system is PCF and Chebyshev, verified in data manually): 
![PR4](https://github.com/oss-slu/dads/assets/126357831/eb7adffd-4d23-4e33-9658-74132685118e)
