### PR TITLE
Populating details tables

### DIFF
--- a/Backend/PostgresConnector.py
+++ b/Backend/PostgresConnector.py
@@ -25,15 +25,22 @@ class PostgresConnector:
         result = cur.fetchall()
         cur.close()
         return result
-
-    # gets a system identified by its label, input is string
-    def getSystem(self,label):
+    
+    def getSystem(self, label):
         columns = '*'
-        sql = "SELECT " + columns + " FROM functions_dim_1_NF WHERE label = '" + label + "'"
-        cur = self.connection.cursor()
-        cur.execute(sql)
-        result = cur.fetchall()
-        cur.close()
+        sql = f"""
+            SELECT {columns}
+            FROM functions_dim_1_NF
+            JOIN rational_preperiodic_dim_1_nf ON functions_dim_1_NF.label = rational_preperiodic_dim_1_nf.function_label
+            JOIN graphs_dim_1_nf ON rational_preperiodic_dim_1_nf.graph_id = graphs_dim_1_nf.graph_id
+            WHERE functions_dim_1_NF.label = %s
+            """
+        
+        with self.connection.cursor() as cur:
+            cur.execute(sql, (label,))  
+            result = cur.fetchall()
+            print(result)
+
         return result
 
     # gets systems that match the passed in filters, input should be json object

--- a/Frontend/src/components/FunctionDetail/AutomorphismGroupTable.js
+++ b/Frontend/src/components/FunctionDetail/AutomorphismGroupTable.js
@@ -3,36 +3,32 @@ import Table from '@mui/material/Table';
 import TableBody from '@mui/material/TableBody';
 import TableCell from '@mui/material/TableCell';
 import TableContainer from '@mui/material/TableContainer';
+import TableHead from '@mui/material/TableHead';
 import TableRow from '@mui/material/TableRow';
 import Paper from '@mui/material/Paper';
 
-function createData(label, domain, standardModel, degree, fieldOfDef, minFieldOfDef, fieldOfModull) {
-  return { label, domain, standardModel, degree, fieldOfDef, minFieldOfDef, fieldOfModull };
-}
-
-const rows = [
-  createData('Cardinality', 1),
-  createData('Structure', 'trivial'),
-  createData('As Matrices', 'link'),
-  createData('Field of Definition', 'QQ'),
-];
-
-export default function InfoTable3() {
+export default function AutomorphismGroupTable({ data }) {
   return (
     <TableContainer className='table-component' component={Paper}>
       <h3>Automorphism Group</h3>
       <Table aria-label="simple table">
         <TableBody>
-          {rows.map((row) => (
-            <TableRow
-              key={row.label}
-            >
-              <TableCell component="th" scope="row">
-                <b>{row.label}</b>
-              </TableCell>
-              <TableCell align="right">{row.domain}</TableCell>
-            </TableRow>
-          ))}
+          <TableRow>
+            <TableCell component="th" scope="row"><b>Cardinality</b></TableCell>
+            <TableCell align="right">{data[18]}</TableCell>
+          </TableRow>
+          <TableRow>
+            <TableCell component="th" scope="row"><b>Structure</b></TableCell>
+            <TableCell align="right">{data[0]}</TableCell>
+          </TableRow>
+          <TableRow>
+            <TableCell component="th" scope="row"><b>As Matrices</b></TableCell>
+            <TableCell align="right">{data[1]}</TableCell>
+          </TableRow>
+          <TableRow>
+            <TableCell component="th" scope="row"><b>Field of Definition</b></TableCell>
+            <TableCell align="right">{data[1]}</TableCell>
+          </TableRow>
         </TableBody>
       </Table>
     </TableContainer>

--- a/Frontend/src/components/FunctionDetail/AutomorphismGroupTable.js
+++ b/Frontend/src/components/FunctionDetail/AutomorphismGroupTable.js
@@ -19,15 +19,15 @@ export default function AutomorphismGroupTable({ data }) {
           </TableRow>
           <TableRow>
             <TableCell component="th" scope="row"><b>Structure</b></TableCell>
-            <TableCell align="right">{data[0]}</TableCell>
+            <TableCell align="right">{"trivial"}</TableCell>
           </TableRow>
           <TableRow>
             <TableCell component="th" scope="row"><b>As Matrices</b></TableCell>
-            <TableCell align="right">{data[1]}</TableCell>
+            <TableCell align="right">{"link"}</TableCell>
           </TableRow>
           <TableRow>
             <TableCell component="th" scope="row"><b>Field of Definition</b></TableCell>
-            <TableCell align="right">{data[1]}</TableCell>
+            <TableCell align="right">{"QQ"}</TableCell>
           </TableRow>
         </TableBody>
       </Table>

--- a/Frontend/src/components/FunctionDetail/AutomorphismGroupTable.js
+++ b/Frontend/src/components/FunctionDetail/AutomorphismGroupTable.js
@@ -8,18 +8,6 @@ import TableRow from '@mui/material/TableRow';
 import Paper from '@mui/material/Paper';
 
 export default function AutomorphismGroupTable({ data }) {
-function createData(label, value) {
-  return { label, value };
-}
-
-const rows = [
-  createData('Cardinality', 1),
-  createData('Structure', 'trivial'),
-  createData('As Matrices', 'link'),
-  createData('Field of Definition', 'QQ'),
-];
-
-export default function InfoTable3() {
   return (
     <TableContainer className='table-component' component={Paper}>
       <h3>Automorphism Group</h3>

--- a/Frontend/src/components/FunctionDetail/InfoTable.js
+++ b/Frontend/src/components/FunctionDetail/InfoTable.js
@@ -25,10 +25,10 @@ export default function InfoTable({ data }) {
         </TableHead>
         <TableBody>
           <TableRow>
-            <TableCell component="th" scope="row">{data[10]} </TableCell>
+            <TableCell component="th" scope="row">{data[0]} </TableCell>
             <TableCell align="right"><>P<sup>{Number(data[1])}</sup> {String.fromCharCode(8594)} P<sup>{Number(data[1])}</sup></></TableCell>
             <TableCell align="right">{data[14]}</TableCell>
-            <TableCell align="right">{data[0]}</TableCell>
+            <TableCell align="right">{data[1]}</TableCell>
             <TableCell align="right">{data[5]}</TableCell>
             <TableCell align="right">{data[5]}</TableCell>
             <TableCell align="right">{data[5]}</TableCell>

--- a/Frontend/src/components/FunctionDetail/RationalPointsTable.js
+++ b/Frontend/src/components/FunctionDetail/RationalPointsTable.js
@@ -15,15 +15,15 @@ export default function RationalPointsTable({ data }) {
         <TableBody>
           <TableRow>
             <TableCell component="th" scope="row"><b>Cardinality</b></TableCell>
-            <TableCell align="right">{data[31]}</TableCell>
+            <TableCell align="right">{data.length > 31 ? data[31] : 'N/A'}</TableCell>
           </TableRow>
           <TableRow>
             <TableCell component="th" scope="row"><b>Cycle Sizes</b></TableCell>
-            <TableCell align="right">{data[34].length}</TableCell>
+            <TableCell align="right">{data.length > 34 ? data[34].length : 'N/A'}</TableCell>
           </TableRow>
           <TableRow>
             <TableCell component="th" scope="row"><b>Component Sizes</b></TableCell>
-            <TableCell align="right">{data[33]}</TableCell>
+            <TableCell align="right">{data.length > 33 ? data[33] : 'N/A'}</TableCell>
           </TableRow>
           <TableRow>
             <TableCell component="th" scope="row"><b>As Directed Graph</b></TableCell>

--- a/Frontend/src/components/FunctionDetail/RationalPointsTable.js
+++ b/Frontend/src/components/FunctionDetail/RationalPointsTable.js
@@ -15,23 +15,23 @@ export default function RationalPointsTable({ data }) {
         <TableBody>
           <TableRow>
             <TableCell component="th" scope="row"><b>Cardinality</b></TableCell>
-            <TableCell align="right">{"N/A"}</TableCell>
+            <TableCell align="right">{data[31]}</TableCell>
           </TableRow>
           <TableRow>
             <TableCell component="th" scope="row"><b>Cycle Sizes</b></TableCell>
-            <TableCell align="right">{"P1 -> P1"}</TableCell>
+            <TableCell align="right">{data[34].length}</TableCell>
           </TableRow>
           <TableRow>
             <TableCell component="th" scope="row"><b>Component Sizes</b></TableCell>
-            <TableCell align="right">{"N/A"}</TableCell>
+            <TableCell align="right">{data[33]}</TableCell>
           </TableRow>
           <TableRow>
             <TableCell component="th" scope="row"><b>As Directed Graph</b></TableCell>
-            <TableCell align="right">{"N/A"}</TableCell>
+            <TableCell align="right">{"link"}</TableCell>
           </TableRow>
           <TableRow>
             <TableCell component="th" scope="row"><b>Adjacency Matrix</b></TableCell>
-            <TableCell align="right">{"N/A"}</TableCell>
+            <TableCell align="right">{"link"}</TableCell>
           </TableRow>
         </TableBody>
       </Table>

--- a/Frontend/src/components/FunctionDetail/RationalPointsTable.js
+++ b/Frontend/src/components/FunctionDetail/RationalPointsTable.js
@@ -15,23 +15,23 @@ export default function RationalPointsTable({ data }) {
         <TableBody>
           <TableRow>
             <TableCell component="th" scope="row"><b>Cardinality</b></TableCell>
-            <TableCell align="right">{data[0]}</TableCell>
+            <TableCell align="right">{"N/A"}</TableCell>
           </TableRow>
           <TableRow>
             <TableCell component="th" scope="row"><b>Cycle Sizes</b></TableCell>
-            <TableCell align="right">{data[0]}</TableCell>
+            <TableCell align="right">{"P1 -> P1"}</TableCell>
           </TableRow>
           <TableRow>
             <TableCell component="th" scope="row"><b>Component Sizes</b></TableCell>
-            <TableCell align="right">{data[1]}</TableCell>
+            <TableCell align="right">{"N/A"}</TableCell>
           </TableRow>
           <TableRow>
             <TableCell component="th" scope="row"><b>As Directed Graph</b></TableCell>
-            <TableCell align="right">{data[1]}</TableCell>
+            <TableCell align="right">{"N/A"}</TableCell>
           </TableRow>
           <TableRow>
             <TableCell component="th" scope="row"><b>Adjacency Matrix</b></TableCell>
-            <TableCell align="right">{data[1]}</TableCell>
+            <TableCell align="right">{"N/A"}</TableCell>
           </TableRow>
         </TableBody>
       </Table>

--- a/Frontend/src/components/FunctionDetail/RationalPointsTable.js
+++ b/Frontend/src/components/FunctionDetail/RationalPointsTable.js
@@ -3,37 +3,36 @@ import Table from '@mui/material/Table';
 import TableBody from '@mui/material/TableBody';
 import TableCell from '@mui/material/TableCell';
 import TableContainer from '@mui/material/TableContainer';
+import TableHead from '@mui/material/TableHead';
 import TableRow from '@mui/material/TableRow';
 import Paper from '@mui/material/Paper';
 
-function createData(label, domain, standardModel, degree, fieldOfDef, minFieldOfDef, fieldOfModull) {
-  return { label, domain, standardModel, degree, fieldOfDef, minFieldOfDef, fieldOfModull };
-}
-
-const rows = [
-  createData('Cardinality', 9),
-  createData('Cycle Sizes', 'P1 -> P1'),
-  createData('Component Sizes', '[16x3-21y2: 16y2]'),
-  createData('As Directed Graph', '2'),
-  createData('Adjacency Matrix', 'QQ'),
-];
-
-export default function RationalPointsTable() {
+export default function RationalPointsTable({ data }) {
   return (
     <TableContainer className='table-component' component={Paper}>
       <h3>Rational Preperiodic Points</h3>
       <Table aria-label="simple table">
         <TableBody>
-          {rows.map((row) => (
-            <TableRow
-              key={row.label}
-            >
-              <TableCell component="th" scope="row">
-                <b>{row.label}</b>
-              </TableCell>
-              <TableCell align="right">{row.domain}</TableCell>
-            </TableRow>
-          ))}
+          <TableRow>
+            <TableCell component="th" scope="row"><b>Cardinality</b></TableCell>
+            <TableCell align="right">{data[0]}</TableCell>
+          </TableRow>
+          <TableRow>
+            <TableCell component="th" scope="row"><b>Cycle Sizes</b></TableCell>
+            <TableCell align="right">{data[0]}</TableCell>
+          </TableRow>
+          <TableRow>
+            <TableCell component="th" scope="row"><b>Component Sizes</b></TableCell>
+            <TableCell align="right">{data[1]}</TableCell>
+          </TableRow>
+          <TableRow>
+            <TableCell component="th" scope="row"><b>As Directed Graph</b></TableCell>
+            <TableCell align="right">{data[1]}</TableCell>
+          </TableRow>
+          <TableRow>
+            <TableCell component="th" scope="row"><b>Adjacency Matrix</b></TableCell>
+            <TableCell align="right">{data[1]}</TableCell>
+          </TableRow>
         </TableBody>
       </Table>
     </TableContainer>

--- a/Frontend/src/pages/SystemDetails.js
+++ b/Frontend/src/pages/SystemDetails.js
@@ -54,8 +54,8 @@ function SystemDetails() {
               <MultiplierInvariantsTable />
             </div>
             <div className="row">
-              <RationalPointsTable />
-              <AutomorphismGroupTable />
+              <RationalPointsTable data = {data}/>
+              <AutomorphismGroupTable data = {data}/>
             </div>
             <div className="row">
               <CriticalPointsTable />


### PR DESCRIPTION
Fixes #94

**What was changed?**

The automorphism group table and the rational points table were restructured to use live data passed by the systemdetails.js file which gets the data from the postgres connector using the getsystem method. These tables are passed a data object which can be indexed to reference the different columns of the relevant database tables. Only one API call is made, and the data obtained can be passed to multiple tables for population. 

**Why was it changed?**

The previous tables only contained static information and contained no information about the actual system

**How was it changed?**

Updated the structure of the table to accept a data object, passed this data in systemdetails, and indexed the data object within the table itself to populate the table. 

**Screenshots that show the changes (if applicable):**

Cardinality 3 - 
![image](https://github.com/oss-slu/dads/assets/126357831/ca7384be-3b4c-4ee5-ad36-69b6f8fb153c)

![image](https://github.com/oss-slu/dads/assets/126357831/c45e8f8c-321b-4deb-9d8b-19e8fa38440c)

Note some of the information is still static. The cardinality and first 3 rational points fields are working correctly, but there are no fields in the database currently corresponding to the other values. Once we know what columns contain this data, it will be as easy as replacing the static text with {data[i]} where i is the column in the data table corresponding to the desired value. Once we meet with Dr. Hutz to determine this, it will be a 5-10 minute fix max. All other functionality is working correctly, I tested the indexing with every value in the table and they all populate as desired, we just need to know which values to use. 
