### PR TITLE
109 back button for details page save state of the filters

### DIFF
--- a/Frontend/src/components/newDataTable.js
+++ b/Frontend/src/components/newDataTable.js
@@ -1,7 +1,6 @@
 import React, { useState } from 'react';
 import Pagination from 'react-bootstrap/Pagination';
-export default function PaginatedDataTable({ labels, data, itemsPerPage }) {
-  const [currentPage, setCurrentPage] = useState(1);
+export default function PaginatedDataTable({ labels, data, itemsPerPage, currentPage, setCurrentPage }) {
 
   const totalPages = Math.ceil(data.length / itemsPerPage);
   const indexOfLastItem = currentPage * itemsPerPage;

--- a/Frontend/src/context/FilterContext.js
+++ b/Frontend/src/context/FilterContext.js
@@ -1,0 +1,29 @@
+import React, { createContext, useContext, useState } from 'react';
+
+const FilterContext = createContext();
+
+export const useFilters = () => useContext(FilterContext);
+
+export const FilterProvider = ({ children }) => {
+    const [filters, setFilters] = useState({
+        dimension: [],
+        degree: [],
+        is_polynomial: [],
+        is_Lattes: [],
+        is_Chebyshev:  [],
+        is_Newton:  [],
+        is_pcf: [],
+        customDegree: "",
+        customDimension: "",
+        automorphism_group_cardinality: "",
+        base_field_label: "",
+        base_field_degree: "",
+        indeterminacy_locus_dimension: ""
+    });
+
+    return (
+        <FilterContext.Provider value={{ filters, setFilters }}>
+            {children}
+        </FilterContext.Provider>
+    );
+};

--- a/Frontend/src/index.js
+++ b/Frontend/src/index.js
@@ -2,11 +2,14 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './App.css';
 import App from './App';
+import { FilterProvider } from './context/FilterContext'; 
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
   <React.StrictMode>
-    <App />
+    <FilterProvider> 
+      <App/>
+    </FilterProvider>
   </React.StrictMode>
 );
 

--- a/Frontend/src/pages/ExploreSystems.js
+++ b/Frontend/src/pages/ExploreSystems.js
@@ -13,13 +13,33 @@ import { useFilters } from '../context/FilterContext';
 
 function ExploreSystems() {
     const [stats, setStat] = useState({
-
         numMaps:"",
         avgAUT:"",
         numPCF:"", 
         avgHeight:"",
         avgResultant:""
     });
+
+    const defaultFilters = {
+        dimension: [],
+        degree: [],
+        is_polynomial: [],
+        is_Lattes: [],
+        is_Chebyshev: [],
+        is_Newton: [],
+        is_pcf: [],
+        customDegree: "",
+        customDimension: "",
+        automorphism_group_cardinality: "",
+        base_field_label: "",
+        base_field_degree: "",
+        indeterminacy_locus_dimension: ""
+    };
+
+    const clearFilters = () => {
+        setFilters(defaultFilters);
+    };
+
     const {filters, setFilters} = useFilters();
 
     const handleCheckboxChange = (filterName, filterValue) => {
@@ -31,8 +51,10 @@ function ExploreSystems() {
     };
 
     const handleRadioChange = (filterName, value) => {
-        setFilters({ ...filters, [filterName]: value });
+        const updatedValue = value === '' ? [] : [String(value)];
+        setFilters({ ...filters, [filterName]: updatedValue });
     };
+    
 
     const handleTextChange = (filterName, value) => {
         setFilters({ ...filters, [filterName]: value });
@@ -422,24 +444,16 @@ function ExploreSystems() {
                                         <input
                                             type="number"
                                             style={textBoxStyle}
-                                            onChange={(event) =>
-                                                replaceFilter(
-                                                    "base_field_degree",
-                                                    event.target.value
-                                                )
-                                            }
+                                            value={filters.base_field_degree || ''}
+                                            onChange={(e) => handleTextChange("base_field_degree", e.target.value)}
                                         />
                                         <label>Degree</label>
                                         <br />
                                         <input
                                             type="text"
                                             style={textBoxStyle}
-                                            onChange={(event) =>
-                                                replaceFilter(
-                                                    "base_field_label",
-                                                    event.target.value
-                                                )
-                                            }
+                                            value={filters.base_field_label || ''}
+                                            onChange={(e) => handleTextChange("base_field_label", e.target.value)}
                                         />
                                         <label>Label</label>
                                         <br />
@@ -496,12 +510,8 @@ function ExploreSystems() {
                                         <input
                                             type="number"
                                             style={textBoxStyle}
-                                            onChange={(event) =>
-                                                replaceFilter(
-                                                    "automorphism_group_cardinality",
-                                                    event.target.value
-                                                )
-                                            }
+                                            value={filters.automorphism_group_cardinality || ''}
+                                            onChange={(e) => handleTextChange("automorphism_group_cardinality", e.target.value)}
                                         />
                                         <label>Cardinality</label>
                                         <br />
@@ -519,7 +529,8 @@ function ExploreSystems() {
                                                 id="isPCFTrue"
                                                 name="isPCF" 
                                                 value="true"
-                                                onChange={() => replaceFilter('is_pcf', [true])} 
+                                                checked={filters.is_pcf.includes("true")}
+                                                onChange={() => handleRadioChange('is_pcf', true)} 
                                             />
                                             <label htmlFor="isPCFTrue">Is Postcritically Finite</label>
                                         </li>
@@ -529,18 +540,19 @@ function ExploreSystems() {
                                                 id="isPCFFalse"
                                                 name="isPCF" 
                                                 value="false"
-                                                onChange={() => replaceFilter('is_pcf', [false])} 
+                                                checked={filters.is_pcf.includes("false")}
+                                                onChange={() => handleRadioChange('is_pcf', false)} 
                                             />
                                             <label htmlFor="isPCFFalse">Not Postcritically Finite</label>
                                         </li>
                                         <li>
-                                            <input
-                                                type="radio"
+                                            <input 
+                                                type="radio" 
                                                 id="showAll"
-                                                name="isPCF"
+                                                name="isPCF" 
                                                 value="all"
-                                                onChange={() => replaceFilter('is_pcf', [])}
-                                                defaultChecked
+                                                checked={filters.is_pcf.length === 0}
+                                                onChange={() => handleRadioChange('is_pcf', '')} 
                                             />
                                             <label htmlFor="showAll">Show all</label>
                                         </li>
@@ -560,12 +572,8 @@ function ExploreSystems() {
                                         <input
                                             type="number"
                                             style={textBoxStyle}
-                                            onChange={(event) =>
-                                                replaceFilter(
-                                                    "indeterminacy_locus_dimension",
-                                                    event.target.value
-                                                )
-                                            }
+                                            value={filters.indeterminacy_locus_dimension || ''}
+                                            onChange={(e) => handleTextChange("indeterminacy_locus_dimension", e.target.value)}
                                         />
                                         <label>Dimension</label>
                                     </ul>
@@ -573,12 +581,17 @@ function ExploreSystems() {
                             </ul>
 
                             <ul id="myUL">
-                                <li>
+                                <li  style={{ paddingBottom: '10px' }}>
                                     <button
                                         style={buttonStyle}
                                         onClick={sendFilters}
                                     >
                                         Get Results
+                                    </button>
+                                </li>
+                                <li>
+                                    <button style={buttonStyle} onClick={clearFilters}>
+                                        Clear Filters
                                     </button>
                                 </li>
                             </ul>

--- a/Frontend/src/pages/ExploreSystems.js
+++ b/Frontend/src/pages/ExploreSystems.js
@@ -7,6 +7,8 @@ import { useState, useEffect } from 'react';
 import { get_filtered_systems, get_selected_systems} from '../api/routes';
 import ReportGeneralError from '../errorreport/ReportGeneralError';
 import ReportMajorError from '../errorreport/ReportMajorError';
+import { useFilters } from '../context/FilterContext'; 
+
 
 
 function ExploreSystems() {
@@ -18,23 +20,24 @@ function ExploreSystems() {
         avgHeight:"",
         avgResultant:""
     });
-    const [filters, setFilters] = useState({
-        dimension: [],
-        degree: [],
-        is_polynomial: [],
-        is_Lattes: [],
+    const {filters, setFilters} = useFilters();
 
-        is_Chebyshev:  [],
-        is_Newton:  [],
-        is_pcf: [],
-        customDegree: "",
-        customDimension: "",
-        automorphism_group_cardinality: "",
-        base_field_label: "",
-        base_field_degree: "",
+    const handleCheckboxChange = (filterName, filterValue) => {
+        const updatedFilters = filters[filterName].includes(filterValue)
+            ? filters[filterName].filter(value => value !== filterValue)
+            : [...filters[filterName], filterValue];
 
-        indeterminacy_locus_dimension: ""
-    });
+        setFilters({ ...filters, [filterName]: updatedFilters });
+    };
+
+    const handleRadioChange = (filterName, value) => {
+        setFilters({ ...filters, [filterName]: value });
+    };
+
+    const handleTextChange = (filterName, value) => {
+        setFilters({ ...filters, [filterName]: value });
+    };
+    
     //add for error notice
     // State for error modals and snackbars
     const [majorError, setMajorError] = useState('');
@@ -167,8 +170,15 @@ function ExploreSystems() {
     };
 
     useEffect(() => {
+        const savedFilters = sessionStorage.getItem('filters');
+        if (savedFilters) {
+          const parsedFilters = JSON.parse(savedFilters);
+          setFilters(parsedFilters); 
+        }
+      
         fetchFilteredSystems();
-     }, []); 
+      }, []); 
+      
      
     const toggleTree = (event) => {
         let el = event.target;
@@ -266,9 +276,8 @@ function ExploreSystems() {
                                     <ul className="nested">
                                         <input
                                             type="checkbox"
-                                            onClick={() =>
-                                                appendFilter("dimension", 1)
-                                            }
+                                            checked={filters.dimension.includes(1)}
+                                            onChange={() => handleCheckboxChange("dimension", 1)}
                                         />
                                         <label>
                                             P<sup>1</sup>{" "}
@@ -277,10 +286,9 @@ function ExploreSystems() {
                                         </label>
                                         <br />
                                         <input
-                                            type="checkbox"
-                                            onClick={() =>
-                                                appendFilter("dimension", 2)
-                                            }
+                                        type="checkbox"
+                                        checked={filters.dimension.includes(2)}
+                                        onChange={() => handleCheckboxChange("dimension", 2)}
                                         />
                                         <label>
                                             P<sup>2</sup>{" "}
@@ -291,12 +299,8 @@ function ExploreSystems() {
                                         <input
                                             type="number"
                                             style={textBoxStyle}
-                                            onChange={(event) =>
-                                                replaceFilter(
-                                                    "customDimension",
-                                                    event.target.value
-                                                )
-                                            }
+                                            value={filters.customDimension}
+                                            onChange={(e) => handleTextChange("customDimension", e.target.value)}
                                         />
                                         <label>Custom</label>
                                         <br />
@@ -315,37 +319,30 @@ function ExploreSystems() {
                                     <ul className="nested">
                                         <input
                                             type="checkbox"
-                                            onClick={() =>
-                                                appendFilter("degree", 2)
-                                            }
+                                            checked={filters.degree.includes(2)}
+                                            onChange={() => handleCheckboxChange("degree", 2)}
                                         />
                                         <label>2</label>
                                         <br />
                                         <input
                                             type="checkbox"
-                                            onClick={() =>
-                                                appendFilter("degree", 3)
-                                            }
+                                            checked={filters.degree.includes(3)}
+                                            onChange={() => handleCheckboxChange("degree", 3)}
                                         />
                                         <label>3</label>
                                         <br />
                                         <input
                                             type="checkbox"
-                                            onClick={() =>
-                                                appendFilter("degree", 4)
-                                            }
+                                            checked={filters.degree.includes(4)}
+                                            onChange={() => handleCheckboxChange("degree", 4)}
                                         />
                                         <label>4</label>
                                         <br />
                                         <input
                                             type="number"
                                             style={textBoxStyle}
-                                            onChange={(event) =>
-                                                replaceFilter(
-                                                    "customDegree",
-                                                    event.target.value
-                                                )
-                                            }
+                                            value={filters.customDegree || ''}
+                                            onChange={(e) => handleTextChange("customDegree", e.target.value)}
                                         />
                                         <label>Custom</label>
                                         <br />
@@ -383,33 +380,29 @@ function ExploreSystems() {
                                     <ul className="nested">
                                         <input
                                             type="checkbox"
-                                            onClick={() =>
-                                                booleanFilter("is_polynomial")
-                                            }
+                                            checked={filters.is_polynomial.includes(true)}
+                                            onChange={() => handleCheckboxChange("is_polynomial", true)}
                                         />
                                         <label>Polynomial</label>
                                         <br />
                                         <input
                                             type="checkbox"
-                                            onClick={() =>
-                                                booleanFilter("is_Lattes")
-                                            }
+                                            checked={filters.is_Lattes.includes(true)}
+                                            onChange={() => handleCheckboxChange("is_Lattes", true)}
                                         />
                                         <label>Lattes</label>
                                         <br />
                                         <input
                                             type="checkbox"
-                                            onClick={() =>
-                                                booleanFilter("is_Chebyshev")
-                                            }
+                                            checked={filters.is_Chebyshev.includes(true)}
+                                            onChange={() => handleCheckboxChange("is_Chebyshev", true)}
                                         />
                                         <label>Chebyshev</label>
                                         <br />
                                         <input
                                             type="checkbox"
-                                            onClick={() =>
-                                                booleanFilter("is_Newton")
-                                            }
+                                            checked={filters.is_Newton.includes(true)}
+                                            onChange={() => handleCheckboxChange("is_Newton", true)}
                                         />
                                         <label>Newton</label>
                                         <br />

--- a/Frontend/src/pages/ExploreSystems.js
+++ b/Frontend/src/pages/ExploreSystems.js
@@ -41,7 +41,6 @@ function ExploreSystems() {
         setTriggerFetch(prev => !prev);
     };
 
-
     const {filters, setFilters} = useFilters();
 
     const handleCheckboxChange = (filterName, filterValue) => {
@@ -193,15 +192,37 @@ function ExploreSystems() {
         }
     };
 
+    const [currentPage, setCurrentPage] = useState(() => {
+        return sessionStorage.getItem('currentPage') ? parseInt(sessionStorage.getItem('currentPage'), 10) : 1;
+    });
+      
+
+    useEffect(() => {
+        sessionStorage.setItem('currentPage', currentPage.toString());
+      }, [currentPage]); 
+      
     useEffect(() => {
         const savedFilters = sessionStorage.getItem('filters');
+        const savedPage = sessionStorage.getItem('currentPage');
+        const savedResultsPerPage = sessionStorage.getItem('resultsPerPage');
+      
         if (savedFilters) {
           const parsedFilters = JSON.parse(savedFilters);
-          setFilters(parsedFilters); 
+          setFilters(parsedFilters);
+        }
+      
+        if (savedPage) {
+          setCurrentPage(Number(savedPage));
+        }
+      
+        if (savedResultsPerPage) {
+          setPagesPer(savedResultsPerPage);
+          setPagesDisplay(savedResultsPerPage === systems?.length.toString() ? 'All' : savedResultsPerPage);
         }
       
         fetchFilteredSystems();
       }, []); 
+       
       
     useEffect(() => {
         fetchFilteredSystems();
@@ -213,38 +234,24 @@ function ExploreSystems() {
         el.classList.toggle("caret-down");
     };
 
-    //used to update a boolean filter, filter is [] if false so that it doesn't matter
-    //assumes defaulted to false (UNCHECKED)
-    const booleanFilter = (filterName) => {
-        if (filters[filterName].length === 0) {
-            setFilters({ ...filters, [filterName]: [true] });
-        } else {
-            setFilters({ ...filters, [filterName]: [] });
-        }
+    const sendFilters = () => {
+        setSystems(null);
+        fetchFilteredSystems();
+        setTriggerFetch(prev => !prev);
     };
 
-    //used to set a filter property, replacing it with the old value
-    const replaceFilter = (filterName, filterValue) => {
-        setFilters({ ...filters, [filterName]: filterValue });
-    };
+    const [pagesPer, setPagesPer] = useState('20');
 
-    //used to add to a filter property that can contain multiple values
-    const appendFilter = (filterName, filterValue) => {
-        //remove it from list
-        if (filters[filterName].includes(filterValue)) {
-            setFilters({
-                ...filters,
-                [filterName]: filters[filterName].filter(
-                    (item) => item !== filterValue
-                ),
-            });
-        }
-        //add it to list
-        else {
-            filters[filterName].push(filterValue);
-        }
-    };
+    const [pagesDisplay, setPagesDisplay] = useState('20');
 
+    const handlePagePerChange = (event) => {
+        const value = event.target.value === 'All' ? systems?.length.toString() : event.target.value;
+        setPagesPer(value);
+        setPagesDisplay(event.target.value === 'All' ? 'All' : value);
+      
+        sessionStorage.setItem('resultsPerPage', value);
+    };
+      
     const textBoxStyle = {
         width: "60px",
         marginRight: "12px",
@@ -269,29 +276,6 @@ function ExploreSystems() {
         padding: "6px 75px",
         borderRadius: "4px",
     };
-
-    const sendFilters = () => {
-        setSystems(null);
-        fetchFilteredSystems();
-        setTriggerFetch(prev => !prev);
-    };
-
-    
-    const [pagesPer, setPagesPer] = useState('20');
-
-    const [pagesDisplay, setPagesDisplay] = useState('20');
-
-    const handlePagePerChange = (event) => {
-    // Update the state with the selected value
-    if (event.target.value == 'All'){
-	setPagesPer(systems.length);
-	setPagesDisplay("All");
-    } else {
-	setPagesPer(event.target.value);
-	setPagesDisplay(event.target.value);
-    }
-  };
-
 
     return (
         <>
@@ -672,7 +656,9 @@ function ExploreSystems() {
                                           </span>,
                                       ])
                             }
-                            itemsPerPage={pagesPer} // You can adjust the number of items per page as needed
+                            itemsPerPage={pagesPer}
+                            currentPage={currentPage} 
+                            setCurrentPage={setCurrentPage}
                         />
 
                         {connectionStatus === false ? (

--- a/Frontend/src/pages/ExploreSystems.js
+++ b/Frontend/src/pages/ExploreSystems.js
@@ -256,6 +256,16 @@ function ExploreSystems() {
         color: "white",
         cursor: "pointer",
         fontSize: "15px",
+        padding: "6px 76.5px",
+        borderRadius: "4px",
+    };
+
+    const redButtonStyle = {
+        border: "none",
+        backgroundColor: "#cc0000",
+        color: "white",
+        cursor: "pointer",
+        fontSize: "15px",
         padding: "6px 75px",
         borderRadius: "4px",
     };
@@ -593,11 +603,11 @@ function ExploreSystems() {
                                         style={buttonStyle}
                                         onClick={sendFilters}
                                     >
-                                        Get Results
+                                        Get Results 
                                     </button>
                                 </li>
                                 <li>
-                                    <button style={buttonStyle} onClick={clearFilters}>
+                                    <button style={redButtonStyle} onClick={clearFilters}>
                                         Clear Filters
                                     </button>
                                 </li>

--- a/Frontend/src/pages/ExploreSystems.js
+++ b/Frontend/src/pages/ExploreSystems.js
@@ -9,8 +9,6 @@ import ReportGeneralError from '../errorreport/ReportGeneralError';
 import ReportMajorError from '../errorreport/ReportMajorError';
 import { useFilters } from '../context/FilterContext'; 
 
-
-
 function ExploreSystems() {
     const [stats, setStat] = useState({
         numMaps:"",
@@ -36,9 +34,13 @@ function ExploreSystems() {
         indeterminacy_locus_dimension: ""
     };
 
+    const [triggerFetch, setTriggerFetch] = useState(false);
+
     const clearFilters = () => {
         setFilters(defaultFilters);
+        setTriggerFetch(prev => !prev);
     };
+
 
     const {filters, setFilters} = useFilters();
 
@@ -201,7 +203,10 @@ function ExploreSystems() {
         fetchFilteredSystems();
       }, []); 
       
-     
+    useEffect(() => {
+        fetchFilteredSystems();
+    }, [triggerFetch]); 
+    
     const toggleTree = (event) => {
         let el = event.target;
         el.parentElement.querySelector(".nested").classList.toggle("active");
@@ -258,7 +263,9 @@ function ExploreSystems() {
     const sendFilters = () => {
         setSystems(null);
         fetchFilteredSystems();
+        setTriggerFetch(prev => !prev);
     };
+
     
     const [pagesPer, setPagesPer] = useState('20');
 

--- a/Frontend/src/pages/ExploreSystems.js
+++ b/Frontend/src/pages/ExploreSystems.js
@@ -111,11 +111,13 @@ function ExploreSystems() {
     const clearFilters = () => {
         setFilters(defaultFilters);
         setTriggerFetch(prev => !prev);
+        setCurrentPage(1);
     };
 
     // API Call Functions
     const fetchFilteredSystems = async () => {
         try {
+            setCurrentPage(1);
             const result = await get_filtered_systems(
                 {
                     degree: filters.customDegree === "" ? filters.degree : [...filters.degree, Number(filters.customDegree)],

--- a/Frontend/src/pages/SystemDetails.js
+++ b/Frontend/src/pages/SystemDetails.js
@@ -1,6 +1,6 @@
 import { get_system } from '../api/routes';
 import { useState, useEffect } from 'react';
-import { useParams, useNavigate } from "react-router-dom";
+import { useParams } from "react-router-dom";
 import InfoTable from '../components/FunctionDetail/InfoTable'
 import RationalPointsTable from '../components/FunctionDetail/RationalPointsTable'
 import AutomorphismGroupTable from '../components/FunctionDetail/AutomorphismGroupTable'
@@ -9,7 +9,6 @@ import CriticalPointPortraitTable from '../components/FunctionDetail/CriticalPoi
 import ModelsTable from '../components/FunctionDetail/ModelsTable'
 import CitationsTable from '../components/FunctionDetail/CitationsTable'
 import { useFilters } from '../context/FilterContext';
-
 
 function SystemDetails() {
     const [data, setData] = useState({});
@@ -34,23 +33,13 @@ function SystemDetails() {
 
   const { filters } = useFilters(); 
 
-  const navigate = useNavigate(); // Initialize useHistory hook
-
-  const handleBack = () => {
-    navigate('/exploreSystems');
-  };
-
   console.log(data)
     return (
         <>
-            
             <div>
                 <div className="info-container">
             <div className="row">
               <InfoTable data = {data}/>
-            </div>
-            <div>
-              <button onClick={handleBack}>Back</button> 
             </div>
             <div className="row">
               <RationalPointsTable data = {data}/>

--- a/Frontend/src/pages/SystemDetails.js
+++ b/Frontend/src/pages/SystemDetails.js
@@ -1,6 +1,6 @@
 import { get_system } from '../api/routes';
 import { useState, useEffect } from 'react';
-import { useParams } from "react-router-dom";
+import { useParams, useNavigate } from "react-router-dom";
 import InfoTable from '../components/FunctionDetail/InfoTable'
 import RationalPointsTable from '../components/FunctionDetail/RationalPointsTable'
 import AutomorphismGroupTable from '../components/FunctionDetail/AutomorphismGroupTable'
@@ -8,6 +8,8 @@ import CriticalPointsTable from '../components/FunctionDetail/CriticalPointsTabl
 import CriticalPointPortraitTable from '../components/FunctionDetail/CriticalPointPortraitTable'
 import ModelsTable from '../components/FunctionDetail/ModelsTable'
 import CitationsTable from '../components/FunctionDetail/CitationsTable'
+import { useFilters } from '../context/FilterContext';
+
 
 function SystemDetails() {
     const [data, setData] = useState({});
@@ -29,13 +31,26 @@ function SystemDetails() {
           return []
       } 
   };
+
+  const { filters } = useFilters(); 
+
+  const navigate = useNavigate(); // Initialize useHistory hook
+
+  const handleBack = () => {
+    navigate('/exploreSystems');
+  };
+
   console.log(data)
     return (
         <>
+            
             <div>
                 <div className="info-container">
             <div className="row">
               <InfoTable data = {data}/>
+            </div>
+            <div>
+              <button onClick={handleBack}>Back</button> 
             </div>
             <div className="row">
               <RationalPointsTable data = {data}/>


### PR DESCRIPTION
Fixes #109 

**What was changed?**

Added a new context file to store current filter state globally between all pages, which allows filters to be saved and restored when navigating around the website. Pagination is now reset on filter change. To avoid any inconvenience with forgetting to uncheck filters, I added a clear filters button to reset all filters. Additionally, all checkboxes, radio buttons, and text boxes are repopulated upon visiting the explore systems page to indicate the currently selected filters. 

Components modified: 
Added context file
Modified ExploreSystems.js
Modified SystemDetails.js
Wrapped index.js app component in a wrapper to allow for globalization of filters data

**Why was it changed?**

To allow for preservation of filters while navigating, keeps track of current query incase we want to revisit it. Clear filters added to avoid any potential headaches this restructure would cause users. 

**How was it changed?**

Modified all inputs to be checked based on conditions on the current filters object, added context file to store the filters object, added clear filters button which just sets filters to be a default filters object i.e., all filters empty. 

**Screenshots that show the changes (if applicable):**

See current explore systems page formatting:
![image](https://github.com/oss-slu/dads/assets/126357831/357f8fe0-5d3a-4c2a-8424-d372b4a8bbd7)
