### PR TITLE
pagination_must_be_updated_on_change

### DIFF
--- a/Frontend/src/pages/ExploreSystems.js
+++ b/Frontend/src/pages/ExploreSystems.js
@@ -234,6 +234,8 @@ function ExploreSystems() {
 
     const handlePagePerChange = (event) => {
     // Update the state with the selected value
+    //need to set this to update when filtered systems are queried
+    //update number of pages and current page
     if (event.target.value == 'All'){
 	setPagesPer(systems.length);
 	setPagesDisplay("All");


### PR DESCRIPTION
Fixes #96

**What was changed?**

Pagination does not currently update when filters are changed. 

**Why was it changed?**

When filters are changed pagination will not update the page and sometimes display an empty page 

**How was it changed?**

*Here, get into detail about what files you modified, and talk about the most important lines in regards to fixing the issue.*

**Screenshots that show the changes (if applicable):**
