### PR TITLE
Fixing pagination bug

### DIFF
--- a/Frontend/src/pages/ExploreSystems.js
+++ b/Frontend/src/pages/ExploreSystems.js
@@ -72,23 +72,25 @@ function ExploreSystems() {
             : [...filters[filterName], filterValue];
 
         setFilters({ ...filters, [filterName]: updatedFilters });
+
+        sessionStorage.setItem('currentPage', '1');
     };
 
     const handleRadioChange = (filterName, value) => {
         const updatedValue = value === '' ? [] : [String(value)];
         setFilters({ ...filters, [filterName]: updatedValue });
+        sessionStorage.setItem('currentPage', '1');
     };
 
     const handleTextChange = (filterName, value) => {
         setFilters({ ...filters, [filterName]: value });
+        sessionStorage.setItem('currentPage', '1');
     };
 
     const handlePagePerChange = (event) => {
         const value = event.target.value === 'All' ? systems?.length.toString() : event.target.value;
         setPagesPer(value);
         setPagesDisplay(event.target.value === 'All' ? 'All' : value);
-      
-        sessionStorage.setItem('resultsPerPage', value);
     };
 
     const handleMajorErrorClose = () => {
@@ -117,7 +119,14 @@ function ExploreSystems() {
     // API Call Functions
     const fetchFilteredSystems = async () => {
         try {
-            setCurrentPage(1);
+            const savedPage = sessionStorage.getItem('currentPage');
+            const savedFilters = sessionStorage.getItem('filters');
+            const parsedFilters = JSON.parse(savedFilters);
+
+            if(savedPage){
+                setCurrentPage(Number(savedPage));
+            }
+            
             const result = await get_filtered_systems(
                 {
                     degree: filters.customDegree === "" ? filters.degree : [...filters.degree, Number(filters.customDegree)],
@@ -133,6 +142,7 @@ function ExploreSystems() {
                     indeterminacy_locus_dimension: filters.indeterminacy_locus_dimension
                 }
             )
+
             console.log(result.data['results'])
             console.log(result.data['statistics'])
             console.log(result.data)


### PR DESCRIPTION
Fixes #96

**What was changed?**

The page state now saves when the System Details are accessed while resetting to 1 when new results are queried or when the page is refreshed

**Why was it changed?**

The site would have been irksome and confusing for a user to navigate when page state stays the same when filters are changed and may give them the impression that there are no results for their new query. It would have been annoying to have to re-navigate to the page the user was on after opening the details of a system. 

**How was it changed?**

We created a PageContext file to store the current page.  We also save the current page number and current filters to page data for long term storage when SystemDetails is navigated to. Whenever ExploreSystems is returned to, this page value is restored. However, as soon as the get results button is pressed or the clear filters button, page number resets to 0. 

