### PR TITLE
127 display applied filters at the top

### DIFF
--- a/Frontend/src/App.css
+++ b/Frontend/src/App.css
@@ -221,6 +221,7 @@ p.sidebarHead {
 }
 
 .active-filters-container {
+  max-width: 700px;
   display: flex;
   flex-wrap: wrap;
   padding: 10px;

--- a/Frontend/src/App.css
+++ b/Frontend/src/App.css
@@ -213,9 +213,32 @@ p.sidebarHead {
 }
 
 .even-row {
-  background-color: #d0d6db; /* Set the background color for even rows */
+  background-color: #d0d6db; 
 }
 
 .odd-row {
-  background-color: #ffffff; /* Set the background color for odd rows */
+  background-color: #ffffff; 
+}
+
+.active-filters-container {
+  display: flex;
+  flex-wrap: wrap;
+  padding: 10px;
+  background-color: #f2f2f2;
+}
+
+.filter-chip {
+  margin: 5px;
+  padding: 5px 10px;
+  background-color: #ddd; 
+  border-radius: 20px;
+  display: inline-flex;
+  align-items: center;
+}
+
+.filter-chip button {
+  margin-left: 10px;
+  border: none;
+  background-color: transparent;
+  cursor: pointer;
 }

--- a/Frontend/src/components/ActiveFiltersBanner.js
+++ b/Frontend/src/components/ActiveFiltersBanner.js
@@ -1,0 +1,28 @@
+import React from 'react';
+
+const ActiveFiltersBanner = ({ filters, onRemoveFilter }) => {
+    const renderFilter = (key, value) => {
+        return (
+            <div className="filter-chip" key={key}>
+                {key}: {Array.isArray(value) ? value.join(', ') : value}
+                <button onClick={() => onRemoveFilter(key)}>x</button>
+            </div>
+        );
+    };
+
+    return (
+        <div className="active-filters-container">
+            {Object.entries(filters).map(([key, value]) => {
+                if (Array.isArray(value) && value.length > 0) {
+                    return renderFilter(key, value);
+                }
+                if (value && !Array.isArray(value) && value !== "") {
+                    return renderFilter(key, value);
+                }
+                return null;
+            })}
+        </div>
+    );
+};
+
+export default ActiveFiltersBanner;

--- a/Frontend/src/components/ActiveFiltersBanner.js
+++ b/Frontend/src/components/ActiveFiltersBanner.js
@@ -1,26 +1,20 @@
 import React from 'react';
 
-const ActiveFiltersBanner = ({ filters, onRemoveFilter }) => {
+const ActiveFiltersBanner = ({ filters }) => {
     const renderFilter = (key, value) => {
         return (
             <div className="filter-chip" key={key}>
                 {key}: {Array.isArray(value) ? value.join(', ') : value}
-                <button onClick={() => onRemoveFilter(key)}>x</button>
             </div>
         );
     };
 
     return (
         <div className="active-filters-container">
-            {Object.entries(filters).map(([key, value]) => {
-                if (Array.isArray(value) && value.length > 0) {
-                    return renderFilter(key, value);
-                }
-                if (value && !Array.isArray(value) && value !== "") {
-                    return renderFilter(key, value);
-                }
-                return null;
-            })}
+            {Object.entries(filters).filter(([key, value]) =>
+                (Array.isArray(value) && value.length > 0) ||
+                (!Array.isArray(value) && value)
+            ).map(([key, value]) => renderFilter(key, value))}
         </div>
     );
 };

--- a/Frontend/src/pages/ExploreSystems.js
+++ b/Frontend/src/pages/ExploreSystems.js
@@ -22,7 +22,7 @@ function ExploreSystems() {
     const [openMajorErrorModal, setOpenMajorErrorModal] = useState(false);
     const [generalError, setGeneralError] = useState('');
     const [openGeneralErrorSnackbar, setOpenGeneralErrorSnackbar] = useState(false);
-    const [filtersApplied, setFiltersApplied] = useState(false);
+    const [filtersApplied, setFiltersApplied] = useState();
     const [stats, setStat] = useState({
         numMaps:"",
         avgAUT:"",

--- a/Frontend/src/pages/ExploreSystems.js
+++ b/Frontend/src/pages/ExploreSystems.js
@@ -68,15 +68,6 @@ function ExploreSystems() {
     }, [triggerFetch]); 
 
     // Handler Functions
-    const handleRemoveFilter = (filterName) => {
-        const newFilters = { ...filters };
-        if (Array.isArray(newFilters[filterName])) {
-            newFilters[filterName] = [];
-        } else {
-            newFilters[filterName] = ''; 
-        }
-        setFilters(newFilters);
-    };
     
     const handleCheckboxChange = (filterName, filterValue) => {
         const updatedFilters = filters[filterName].includes(filterValue)
@@ -623,7 +614,7 @@ function ExploreSystems() {
 			    <option value="All">All</option>
 			</select>
 			<p></p>
-            <ActiveFiltersBanner filters={filters} onRemoveFilter={handleRemoveFilter} />
+            <ActiveFiltersBanner filters={filters} />
                         <PaginatedDataTable
                             labels={[
                                 "Label",

--- a/Frontend/src/pages/ExploreSystems.js
+++ b/Frontend/src/pages/ExploreSystems.js
@@ -8,6 +8,8 @@ import { get_filtered_systems, get_selected_systems} from '../api/routes';
 import ReportGeneralError from '../errorreport/ReportGeneralError';
 import ReportMajorError from '../errorreport/ReportMajorError';
 import { useFilters } from '../context/FilterContext'; 
+import ActiveFiltersBanner from '../components/ActiveFiltersBanner'; 
+
 
 function ExploreSystems() {
 
@@ -66,6 +68,16 @@ function ExploreSystems() {
     }, [triggerFetch]); 
 
     // Handler Functions
+    const handleRemoveFilter = (filterName) => {
+        const newFilters = { ...filters };
+        if (Array.isArray(newFilters[filterName])) {
+            newFilters[filterName] = [];
+        } else {
+            newFilters[filterName] = ''; 
+        }
+        setFilters(newFilters);
+    };
+    
     const handleCheckboxChange = (filterName, filterValue) => {
         const updatedFilters = filters[filterName].includes(filterValue)
             ? filters[filterName].filter(value => value !== filterValue)
@@ -611,6 +623,7 @@ function ExploreSystems() {
 			    <option value="All">All</option>
 			</select>
 			<p></p>
+            <ActiveFiltersBanner filters={filters} onRemoveFilter={handleRemoveFilter} />
                         <PaginatedDataTable
                             labels={[
                                 "Label",

--- a/Frontend/src/pages/ExploreSystems.js
+++ b/Frontend/src/pages/ExploreSystems.js
@@ -22,6 +22,7 @@ function ExploreSystems() {
     const [openMajorErrorModal, setOpenMajorErrorModal] = useState(false);
     const [generalError, setGeneralError] = useState('');
     const [openGeneralErrorSnackbar, setOpenGeneralErrorSnackbar] = useState(false);
+    const [filtersApplied, setFiltersApplied] = useState(false);
     const [stats, setStat] = useState({
         numMaps:"",
         avgAUT:"",
@@ -109,6 +110,7 @@ function ExploreSystems() {
         setSystems(null);
         fetchFilteredSystems();
         setTriggerFetch(prev => !prev);
+        setFiltersApplied(true);
     };
 
     const clearFilters = () => {
@@ -614,7 +616,8 @@ function ExploreSystems() {
 			    <option value="All">All</option>
 			</select>
 			<p></p>
-            <ActiveFiltersBanner filters={filters} />
+            {filtersApplied && <ActiveFiltersBanner filters={filters} />}
+
                         <PaginatedDataTable
                             labels={[
                                 "Label",

--- a/Frontend/src/pages/ExploreSystems.js
+++ b/Frontend/src/pages/ExploreSystems.js
@@ -110,7 +110,6 @@ function ExploreSystems() {
         setSystems(null);
         fetchFilteredSystems();
         setTriggerFetch(prev => !prev);
-        setFiltersApplied(true);
     };
 
     const clearFilters = () => {
@@ -142,6 +141,7 @@ function ExploreSystems() {
             console.log(result.data['statistics'])
             console.log(result.data)
             setSystems(result.data['results']);
+            setFiltersApplied({...filters})
             setStat((previousState => {
                 return { ...previousState, numMaps:result.data['statistics'][0], avgAUT:Math.round(result.data['statistics'][1]*100)/100, numPCF:result.data['statistics'][2], avgHeight:Math.round(result.data['statistics'][3]*100)/100, avgResultant:Math.round(result.data['statistics'][4]*100)/100}
             }))
@@ -616,7 +616,7 @@ function ExploreSystems() {
 			    <option value="All">All</option>
 			</select>
 			<p></p>
-            {filtersApplied && <ActiveFiltersBanner filters={filters} />}
+            {filtersApplied && <ActiveFiltersBanner filters={filtersApplied} />}
 
                         <PaginatedDataTable
                             labels={[


### PR DESCRIPTION
Fixes #127 

**What was changed?**

A banner was added to display active filters as chips rather than finding them manually in the dropdown menus

**Why was it changed?**

User convenience and UI improvement

**How was it changed?**

Added an active filters banner reusable component to store the chip logic and display functionality, added css for styling, and added the component into exploresystems.js above the paginated data table

**Screenshots that show the changes (if applicable):**
![image](https://github.com/oss-slu/dads/assets/126357831/a95430d7-ba36-4065-8724-5645fa1dd6d1)![image](https://github.com/oss-slu/dads/assets/126357831/3f7e58b6-dd75-4b1a-a1b7-712f16da63a0)

