### PR TITLE
SuperScripting now rendered, and copy Sage Math Buttons working

### DIFF
--- a/Frontend/src/App.css
+++ b/Frontend/src/App.css
@@ -334,3 +334,9 @@ p.sidebarHead {
 
 }
 
+.superscript {
+  font-size: smaller;
+  vertical-align: super;
+}
+
+

--- a/Frontend/src/components/FunctionDetail/Copy.js
+++ b/Frontend/src/components/FunctionDetail/Copy.js
@@ -1,0 +1,66 @@
+import React, { useState } from 'react';
+
+const Copy = ({ edges, type }) => {
+
+    const generateAdjacencyMatrix = (adjacencyString) => {
+	const adjacencyList = adjacencyString.replace(/\[|\]/g, '').split(', ');
+
+	const adjacencyListInt = adjacencyList.map(Number);
+	console.log('adjacencyListInt:', adjacencyListInt);
+
+
+	const numVertices = adjacencyList.length;
+	console.log('numVertices:', numVertices);
+
+	const adjacencyMatrix = Array.from({ length: numVertices }, () => Array(numVertices).fill(0));
+	console.log('adjacencyMatrix:', adjacencyMatrix);
+
+	for (let i = 0; i < adjacencyListInt.length; i++) {
+	    const adjacentVertex = adjacencyListInt[i];
+	    adjacencyMatrix[i][adjacentVertex] = 1;
+	}
+
+	console.log('adjacencyMatrix after population:', adjacencyMatrix);
+
+	return adjacencyMatrix;
+    }
+    
+    const matrix = generateAdjacencyMatrix(edges);
+    const dimNum = matrix.length;
+
+  const [copySuccess, setCopySuccess] = useState(false);
+  let stringToCopy = "";
+
+  // Set stringToCopy based on the type
+  switch (type) {
+    case 1:
+      stringToCopy = "Matrix(QQ, " + dimNum +","  + dimNum + ", [" + matrix + "])";
+      break;
+    case 2:
+      stringToCopy = "DiGraph(Matrix(QQ, " + dimNum +","  + dimNum + ", [" + matrix + "]))";
+      break;
+    default:
+      stringToCopy = "ERROR";
+  }
+
+  const copyToClipboard = () => {
+    navigator.clipboard.writeText(stringToCopy)
+      .then(() => {
+        setCopySuccess(true);
+        setTimeout(() => {
+          setCopySuccess(false);
+        }, 2000); // Reset success message after 2 seconds
+      })
+      .catch(err => console.error('Failed to copy:', err));
+  };
+
+  return (
+    <div>
+      <button onClick={copyToClipboard}>Copy to Clipboard</button>
+      {copySuccess && <span style={{marginLeft: '10px', color: 'green'}}>Copied!</span>}
+    </div>
+  );
+};
+
+export default Copy;
+

--- a/Frontend/src/components/FunctionDetail/Copy.js
+++ b/Frontend/src/components/FunctionDetail/Copy.js
@@ -56,7 +56,7 @@ const Copy = ({ edges, type }) => {
 
   return (
     <div>
-      <button onClick={copyToClipboard}>Copy to Clipboard</button>
+      <button onClick={copyToClipboard}>Copy Sage Command</button>
       {copySuccess && <span style={{marginLeft: '10px', color: 'green'}}>Copied!</span>}
     </div>
   );

--- a/Frontend/src/components/FunctionDetail/ModelsTable.js
+++ b/Frontend/src/components/FunctionDetail/ModelsTable.js
@@ -15,60 +15,97 @@ export default function ModelsTable({ data }) {
 	modelKeys.splice(position, 1);
     }
 
+   const Superscript = ({ children }) => {
+      return (
+	<sup style={{ fontSize: '0.6em', verticalAlign: 'super' }}>
+	  {children}
+	</sup>
+      );
+    };
+
+    const renderExponent = (expressionArray) => {
+      const formattedExpressions = [];
+
+      expressionArray.forEach((expression, index) => {
+	const parts = expression.split(/(\^[\d]+)/);
+	const formattedExpression = [];
+
+	for (let i = 0; i < parts.length; i++) {
+	  if (parts[i].startsWith('^')) {
+	    const exponentValue = parts[i].slice(1);
+	    formattedExpression.push(<Superscript key={i}>{exponentValue}</Superscript>);
+	  } else {
+	    formattedExpression.push(parts[i]);
+	  }
+	}
+
+	formattedExpressions.push(
+	  <React.Fragment key={index}>
+	    {formattedExpression}
+	    {index !== expressionArray.length - 1 && <span> : </span>}
+	  </React.Fragment>
+	);
+      });
+
+      return formattedExpressions;
+    }; 
+    
+
     function processInput(input) {
-    // Remove outer braces and split by '},{' to get individual polynomial coefficient sets
-    const polynomials = input.slice(2, -2).split('},{');
-    
-    const result = [];
-    
-    // Iterate over each polynomial
-    for (let poly of polynomials) {
-        // Split the polynomial coefficients by ','
-        const coeffs = poly.split(',');
-        
-        // Construct the polynomial expression
-        let polynomialExpression = '';
-        for (let i = 0; i < coeffs.length; i++) {
-            const coefficient = coeffs[i];
-            if (coefficient !== '0') {
-                // Construct monomial expression based on index
-                let monomial = '';
-                if (i === 0) {
-                    monomial = 'x^' + (coeffs.length - 1);
-                } else if (i === coeffs.length - 1) {
-                    monomial = 'y^' + (coeffs.length - 1);
-                } else if (i === 1 && (coeffs.length - 1) === 1) {
-                    monomial = 'xy';
-                } else if (i === 1) {
-                    monomial = 'x^' + (coeffs.length - 1 - i) + 'y';
-                } else if ((coeffs.length - 1 - i) === 1) {
-                    monomial = 'x' + 'y^' + i;
-                } else {
-                    monomial = 'x^' + (coeffs.length - 1 - i) + 'y^' + i;
-                }
-                
-                // Add coefficient with monomial
-                if (coefficient === '1') {
-                    polynomialExpression += monomial;
-                } else if (coefficient === '-1') {
-                    polynomialExpression += '-' + monomial;
-                } else {
-                    polynomialExpression += coefficient + monomial;
-                }
-                
-                // Add '+' if not the last term and coefficient is not zero
-                if (i !== coeffs.length - 1 && coeffs[i + 1] !== '0') {
-                    polynomialExpression += '+';
-                }
-            }
-        }
-        
-        // Push polynomial expression to result array
-        result.push(polynomialExpression);
+	// Remove outer braces and split by '},{' to get individual polynomial coefficient sets
+	const polynomials = input.slice(2, -2).split('},{');
+	
+	const result = [];
+	
+	// Iterate over each polynomial
+	for (let poly of polynomials) {
+	    // Split the polynomial coefficients by ','
+	    const coeffs = poly.split(',');
+	    
+	    // Construct the polynomial expression
+	    let polynomialExpression = '';
+	    for (let i = 0; i < coeffs.length; i++) {
+		const coefficient = coeffs[i];
+		if (coefficient !== '0') {
+		    // Construct monomial expression based on index
+		    let monomial = '';
+		    if (i === 0) {
+			monomial = 'x^' + (coeffs.length - 1);
+		    } else if (i === coeffs.length - 1) {
+			monomial = 'y^' + (coeffs.length - 1);
+		    } else if (i === 1 && (coeffs.length - 1) === 1) {
+			monomial = 'xy';
+		    } else if (i === 1) {
+			monomial = 'x^' + (coeffs.length - 1 - i) + 'y';
+		    } else if ((coeffs.length - 1 - i) === 1) {
+			monomial = 'x' + 'y^' + i;
+		    } else {
+			monomial = 'x^' + (coeffs.length - 1 - i) + 'y^' + i;
+		    }
+		    
+		    // Add coefficient with monomial
+		    if (coefficient === '1') {
+			polynomialExpression += monomial;
+		    } else if (coefficient === '-1') {
+			polynomialExpression += '-' + monomial;
+		    } else {
+			polynomialExpression += coefficient + monomial;
+		    }
+		    
+		    // Add '+' if not the last term and coefficient is not zero
+		    // && coeffs[i + 1] !== '0'
+		    if (i !== coeffs.length - 1 ) {
+			polynomialExpression += '+';
+		    }
+		}
+	    }
+	    
+	    // Push polynomial expression to result array
+	    result.push(polynomialExpression);
+	}
+	
+	return result;
     }
-    
-    return result;
-}
 
   return (
     <TableContainer className='table-component' component={Paper}>
@@ -86,10 +123,13 @@ export default function ModelsTable({ data }) {
         <TableBody>
           {modelKeys.map((key, index) => {
             const modelData = data[key] ? splitOutermostCommas(data[key]) : ['', '', '', '', '']; // Split data[key] or set default values if null
+	    console.log("THIS SHIT RIGHT HERE: ");
+	    console.log(modelData[0]);
+	    console.log(processInput(modelData[0]));
             return (
               <TableRow key={index}>
                 <TableCell align="left">{key.replace(/_/g, ' ').replace(/ model$/, '') + " model"}</TableCell>
-                <TableCell align="left">{processInput(modelData[0])}</TableCell>
+                <TableCell align="left">{renderExponent(processInput(modelData[0]))}</TableCell>
                 <TableCell align="left">{modelData[1]}</TableCell>
                 <TableCell align="left">{modelData[2]}</TableCell>
                 <TableCell align="left">{modelData[5]}</TableCell>

--- a/Frontend/src/components/FunctionDetail/RationalPointsTable.js
+++ b/Frontend/src/components/FunctionDetail/RationalPointsTable.js
@@ -6,6 +6,8 @@ import TableContainer from '@mui/material/TableContainer';
 import TableRow from '@mui/material/TableRow';
 import Paper from '@mui/material/Paper';
 import AdjacencyMatrix from '../FunctionDetail/AdjacencyMatrix'
+import Copy from '../FunctionDetail/Copy'
+
 
 
 export default function RationalPointsTable({ data }) {
@@ -47,11 +49,12 @@ export default function RationalPointsTable({ data }) {
 	      </TableRow>
 	      <TableRow>
 		<TableCell component="th" scope="row"><b>As Directed Graph</b></TableCell>
-		<TableCell align="right">{"link"}</TableCell>
+		<Copy edges={formatData("edges")} type={2}/>
 	      </TableRow>
 	      <TableRow>
 		<TableCell component="th" scope="row"><b>Adjacency Matrix</b></TableCell>
 		<AdjacencyMatrix modalTitle={"Adjacency Matrix"} edges={formatData("edges")}/>
+		<Copy edges={formatData("edges")} type={1}/>
 	      </TableRow>
 	    </TableBody>
 	  </Table>

--- a/Frontend/src/components/newDataTable.js
+++ b/Frontend/src/components/newDataTable.js
@@ -1,10 +1,16 @@
 import Pagination from 'react-bootstrap/Pagination';
 export default function PaginatedDataTable({ labels, data, itemsPerPage, currentPage, setCurrentPage }) {
 
-  const totalPages = Math.ceil(data.length / itemsPerPage);
-  const indexOfLastItem = currentPage * itemsPerPage;
-  const indexOfFirstItem = indexOfLastItem - itemsPerPage;
-  const currentData = data.slice(indexOfFirstItem, indexOfLastItem);
+    const totalPages = Math.ceil(data.length / itemsPerPage);
+    const indexOfLastItem = currentPage * itemsPerPage;
+    const indexOfFirstItem = indexOfLastItem - itemsPerPage;
+    const currentData = data.slice(indexOfFirstItem, indexOfLastItem)
+
+    const renderExponent = (exponent) => {
+        return exponent.replace(/\^(\d+)/g, (_, number) => {
+            return <sup>{number}</sup>;
+        });
+    };
 
   const handlePageChange = (pageNumber) => {
     if(pageNumber <= totalPages && pageNumber >= 1) {
@@ -27,7 +33,7 @@ export default function PaginatedDataTable({ labels, data, itemsPerPage, current
             <tr key={key} className={key % 2 === 0 ? 'even-row' : 'odd-row'} style={{ textAlign: 'center' }}>
               {item.map((element, id) => (
                 <td key={id}>
-                  <span>{element}</span>
+                  <span>{id === 3 ? renderExponent(element) :element}</span>
                 </td>
               ))}
             </tr>

--- a/Frontend/src/components/newDataTable.js
+++ b/Frontend/src/components/newDataTable.js
@@ -6,11 +6,31 @@ export default function PaginatedDataTable({ labels, data, itemsPerPage, current
     const indexOfFirstItem = indexOfLastItem - itemsPerPage;
     const currentData = data.slice(indexOfFirstItem, indexOfLastItem)
 
-    const renderExponent = (exponent) => {
-        return exponent.replace(/\^(\d+)/g, (_, number) => {
-            return <sup>{number}</sup>;
-        });
+    const Superscript = ({ children }) => {
+      return (
+	<sup style={{ fontSize: '0.6em', verticalAlign: 'super' }}>
+	  {children}
+	</sup>
+      );
     };
+    
+  
+    const renderExponent = (exponent) => {
+      const parts = exponent.split(/(\^[\d]+)/);
+      const formattedExpression = [];
+
+      for (let i = 0; i < parts.length; i++) {
+	if (parts[i].startsWith('^')) {
+	  const exponentValue = parts[i].slice(1);
+	  formattedExpression.push(<Superscript key={i}>{exponentValue}</Superscript>);
+	} else {
+	  formattedExpression.push(parts[i]);
+	}
+      }
+
+      return formattedExpression;
+    };
+    
 
   const handlePageChange = (pageNumber) => {
     if(pageNumber <= totalPages && pageNumber >= 1) {


### PR DESCRIPTION
![Screenshot from 2024-05-06 13-32-53](https://github.com/oss-slu/dads/assets/144739653/96402279-f413-469c-85d5-0e013ab69edb)
![Screenshot from 2024-05-06 13-33-30](https://github.com/oss-slu/dads/assets/144739653/a49e7a0d-9682-48b8-9365-158b23f05942)
![Screenshot from 2024-05-06 13-33-48](https://github.com/oss-slu/dads/assets/144739653/2076d8b6-4b7c-4c87-a1d7-ebdbc632f7fb)
# Whats changed? 
- exponents are now displayed as SuperScript in the newDataTable component on the ExplorSystems page, as well as in the ModelsTable in the SystemDetails page. 
- a copy Sage command button is now present to get the Adjacency Matrix and Graph data as a manipulable sage math object. 