### PR TITLE
Issue#141/fixing field filter

### DIFF
--- a/Backend/config.py
+++ b/Backend/config.py
@@ -1,3 +1,8 @@
+"""
+This module contains functionality to load the PostgreSQL
+configuration from a file.
+"""
+
 from configparser import ConfigParser
 
 def load_config(filename='database.ini', section='postgresql'):
@@ -5,15 +10,15 @@ def load_config(filename='database.ini', section='postgresql'):
     parser.read(filename)
 
     # get section, default to postgresql
-    config = {}
+    config_data = {}
     if parser.has_section(section):
         params = parser.items(section)
         for param in params:
-            config[param[0]] = param[1]
+            config_data[param[0]] = param[1]
     else:
-        raise Exception('Section {0} not found in the {1} file'.format(section, filename))
+        raise KeyError(f'Section {section} not found in the {filename} file')
 
-    return config
+    return config_data
 
 if __name__ == '__main__':
     config = load_config()

--- a/Backend/postgres_connector.py
+++ b/Backend/postgres_connector.py
@@ -20,7 +20,6 @@ class PostgresConnector:
         connection: A psycopg2 connection object to interact with the database.
     """
     def __init__(self):
-        
         config = load_config()
         try:
             # connecting to the PostgreSQL server
@@ -296,7 +295,7 @@ class PostgresConnector:
                     )
 
             elif fil in ['base_field_label']:
-                conditions.append(fil + " LIKE \'%" + values + "%\'")
+                conditions.append(fil + "LIKE \'%" + values + "%\'")
             elif fil in ['family']:
                 print(values)
                 query = f"""

--- a/Backend/postgres_connector.py
+++ b/Backend/postgres_connector.py
@@ -24,7 +24,11 @@ class PostgresConnector:
         config = load_config()
         try:
             # connecting to the PostgreSQL server
-            self.connection = psycopg2.connect(**config)
+            self.connection = psycopg2.connect(host="ep-jolly-field-a5mt8r6k.us-east-2.aws.neon.tech",
+                       user="web-app",
+                       dbname="dad",
+                       password="FVhrzfL75eZl",
+                       port="5432")
             print('Connected to the PostgreSQL server.')
 
         except (psycopg2.DatabaseError, Exception) as error:
@@ -296,7 +300,7 @@ class PostgresConnector:
                     )
 
             elif fil in ['base_field_label']:
-                conditions.append(fil + ' LIKE "%" + values + "%"')
+                conditions.append(fil + " LIKE \'%" + values + "%\'")
             elif fil in ['family']:
                 print(values)
                 query = f"""

--- a/Backend/postgres_connector.py
+++ b/Backend/postgres_connector.py
@@ -295,7 +295,7 @@ class PostgresConnector:
                     )
 
             elif fil in ['base_field_label']:
-                conditions.append(fil + "LIKE \'%" + values + "%\'")
+                conditions.append(fil + " LIKE \'%" + values + "%\'")
             elif fil in ['family']:
                 print(values)
                 query = f"""

--- a/Backend/postgres_connector.py
+++ b/Backend/postgres_connector.py
@@ -24,11 +24,7 @@ class PostgresConnector:
         config = load_config()
         try:
             # connecting to the PostgreSQL server
-            self.connection = psycopg2.connect(host="ep-jolly-field-a5mt8r6k.us-east-2.aws.neon.tech",
-                       user="web-app",
-                       dbname="dad",
-                       password="FVhrzfL75eZl",
-                       port="5432")
+            self.connection = psycopg2.connect(**config)
             print('Connected to the PostgreSQL server.')
 
         except (psycopg2.DatabaseError, Exception) as error:


### PR DESCRIPTION
…s to make sure the query formats properly

Fixes #141

**What was changed?**

The `build_where_text()` class was changed. Specifically in the case where the `base_field_label` is used, the input string to `conditons.append()` was changed. 

**Why was it changed?**

When the user would enter anything into the `Label` subfield of the `Field of Definition` filter, the application would respond with "no data meets that criteria", even if there was data that should have matched. This made the filter entirely inoperable and the UI less friendly, as there was no indication of what was going wrong on the user side.

**How was it changed?**

In the old code, the entire input was surrounded by two single quotes making the entire text a string, which included a string variable. In addition, the string around the wildcard characters needs single quotes in order to execute the SQL query correctly. By adding this and tweaking the string so the string variable is a variable rather than a string of the variable name, the query now calls correctly.

