### PR TITLE
added requested subfields for rational preperiodic filter

### DIFF
--- a/Backend/config.py
+++ b/Backend/config.py
@@ -1,3 +1,8 @@
+"""
+This module contains functionality to load the PostgreSQL
+configuration from a file.
+"""
+
 from configparser import ConfigParser
 
 def load_config(filename='database.ini', section='postgresql'):
@@ -5,15 +10,15 @@ def load_config(filename='database.ini', section='postgresql'):
     parser.read(filename)
 
     # get section, default to postgresql
-    config = {}
+    config_data = {}
     if parser.has_section(section):
         params = parser.items(section)
         for param in params:
-            config[param[0]] = param[1]
+            config_data[param[0]] = param[1]
     else:
-        raise Exception('Section {0} not found in the {1} file'.format(section, filename))
+        raise KeyError(f'Section {section} not found in the {filename} file')
 
-    return config
+    return config_data
 
 if __name__ == '__main__':
     config = load_config()

--- a/Backend/postgres_connector.py
+++ b/Backend/postgres_connector.py
@@ -20,7 +20,6 @@ class PostgresConnector:
         connection: A psycopg2 connection object to interact with the database.
     """
     def __init__(self):
-        
         config = load_config()
         try:
             # connecting to the PostgreSQL server

--- a/Frontend/package-lock.json
+++ b/Frontend/package-lock.json
@@ -8130,6 +8130,23 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/eslint-plugin-promise": {
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-6.6.0.tgz",
+      "integrity": "sha512-57Zzfw8G6+Gq7axm2Pdo3gW/Rx3h9Yywgn61uE/3elTCOePEHVrn2i5CdfBwA1BLK0Q0WqctICIUSqXZW/VprQ==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true,
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^7.0.0 || ^8.0.0 || ^9.0.0"
+      }
+    },
     "node_modules/eslint-plugin-react": {
       "version": "7.32.2",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.32.2.tgz",
@@ -17509,6 +17526,20 @@
       "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
       "dependencies": {
         "is-typedarray": "^1.0.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
       }
     },
     "node_modules/unbox-primitive": {

--- a/Frontend/src/pages/ExploreSystems.js
+++ b/Frontend/src/pages/ExploreSystems.js
@@ -486,10 +486,38 @@ function ExploreSystems() {
                                     >
                                         Rational Preperiodic Points
                                     </span>
-                                    <ul className="nested"></ul>
+                                    <ul className="nested">
+                                        <li>
+                                            <input
+                                                type="number"
+                                                style={textBoxStyle}
+                                                value={filters.rationalPreperiodicCardinality || ''}
+                                                onChange={(e) => handleTextChange("rationalPreperiodicCardinality", e.target.value)}
+                                            />
+                                            <label>Cardinality</label>
+                                        </li>
+                                        <li>
+                                            <input
+                                                type="number"
+                                                style={textBoxStyle}
+                                                value={filters.rationalPreperiodicComponents || ''}
+                                                onChange={(e) => handleTextChange("rationalPreperiodicComponents", e.target.value)}
+                                            />
+                                            <label>No of Connected Components</label>
+                                        </li>
+                                        <li>
+                                            <input
+                                                type="number"
+                                                style={textBoxStyle}
+                                                value={filters.rationalPreperiodicLongestTail || ''}
+                                                onChange={(e) => handleTextChange("rationalPreperiodicLongestTail", e.target.value)}
+                                            />
+                                            <label>Longest Tail</label>
+                                        </li>
+                                    </ul>
                                 </li>
                             </ul>
-
+ 
                             <ul id="myUL">
                                 <li>
                                     <span


### PR DESCRIPTION
Fixes #149

**What was changed**

This pull request adds new subfields to the Rational Preperiodic Points filter in the ExploreSystems.js file. The following subfields have been added to the UI:

Cardinality
Number of Connected Components
Longest Tail

These additions enhance the filtering capabilities for rational preperiodic points, allowing users to input more specific criteria for their searches.

**Why was it changed**

These changes were implemented to provide users with more granular control over their searches related to rational preperiodic points. By adding these subfields, we enable users to filter dynamical systems based on specific characteristics of their rational preperiodic point structure, which is crucial for various research and analysis tasks in dynamical systems.

**How was it changed**

The following technical changes were made to implement this feature:

Updated the ExploreSystems.js file:

Added new input fields for each subfield under the "Rational Preperiodic Points" filter section.
Modified the defaultFilters object to include new state variables for these subfields.
Updated the handleTextChange function to handle changes in the new input fields.

UI Modifications:

Added number input fields for each new subfield, styled consistently with existing filters.
Implemented the toggleTree functionality to show/hide the new subfields.

State Management:

Added new state variables in the filters object to store the values of these new subfields.
Ensured that the new filter values are properly reset when clearing all filters.

**Note on Backend Integration:**

The backend API call (get_filtered_systems) has not been modified in this PR. Future work will be needed to integrate these new filter options with the backend filtering logic.

**Screenshots that show the changes (if applicable):**

<img width="1076" alt="Screenshot 2024-09-16 at 11 44 25 AM" src="https://github.com/user-attachments/assets/a1d4c41c-a0a3-4a96-af44-5735c766382e">