### PR TITLE
143 rational preperiodic filter not implemented

### DIFF
--- a/Backend/postgres_connector.py
+++ b/Backend/postgres_connector.py
@@ -231,9 +231,11 @@ class PostgresConnector:
                     'SELECT COUNT( (original_model).height )'
                     ' FROM functions_dim_1_NF'
                     ' JOIN rational_preperiodic_dim_1_nf'
-                    ' ON functions_dim_1_nf.function_id = rational_preperiodic_dim_1_nf.function_id'
+                    ' ON functions_dim_1_nf.function_id ='
+                    ' rational_preperiodic_dim_1_nf.function_id'
                     ' JOIN graphs_dim_1_nf'
-                    ' ON graphs_dim_1_nf.graph_id = rational_preperiodic_dim_1_nf.graph_id'
+                    ' ON graphs_dim_1_nf.graph_id ='
+                    ' rational_preperiodic_dim_1_nf.graph_id'
                     + where_text
                 )
                 cur.execute(sql)
@@ -243,9 +245,11 @@ class PostgresConnector:
                     'SELECT AVG(automorphism_group_cardinality::int)'
                     ' FROM functions_dim_1_NF'
                     ' JOIN rational_preperiodic_dim_1_nf'
-                    ' ON functions_dim_1_nf.function_id = rational_preperiodic_dim_1_nf.function_id'
+                    ' ON functions_dim_1_nf.function_id ='
+                    ' rational_preperiodic_dim_1_nf.function_id'
                     ' JOIN graphs_dim_1_nf'
-                    ' ON graphs_dim_1_nf.graph_id = rational_preperiodic_dim_1_nf.graph_id'
+                    ' ON graphs_dim_1_nf.graph_id ='
+                    ' rational_preperiodic_dim_1_nf.graph_id'
                     + where_text
                 )
                 cur.execute(sql)
@@ -254,9 +258,11 @@ class PostgresConnector:
                 sql = (
                     'SELECT SUM(is_PCF::int) FROM functions_dim_1_NF'
                     ' JOIN rational_preperiodic_dim_1_nf'
-                    ' ON functions_dim_1_nf.function_id = rational_preperiodic_dim_1_nf.function_id'
+                    ' ON functions_dim_1_nf.function_id ='
+                    ' rational_preperiodic_dim_1_nf.function_id'
                     ' JOIN graphs_dim_1_nf'
-                    ' ON graphs_dim_1_nf.graph_id = rational_preperiodic_dim_1_nf.graph_id'
+                    ' ON graphs_dim_1_nf.graph_id ='
+                    ' rational_preperiodic_dim_1_nf.graph_id'
                     + where_text
                 )
                 cur.execute(sql)
@@ -266,9 +272,11 @@ class PostgresConnector:
                     'SELECT AVG( (original_model).height ) ' 
                     'FROM functions_dim_1_NF' 
                     ' JOIN rational_preperiodic_dim_1_nf'
-                    ' ON functions_dim_1_nf.function_id = rational_preperiodic_dim_1_nf.function_id'
+                    ' ON functions_dim_1_nf.function_id ='
+                    ' rational_preperiodic_dim_1_nf.function_id'
                     ' JOIN graphs_dim_1_nf'
-                    ' ON graphs_dim_1_nf.graph_id = rational_preperiodic_dim_1_nf.graph_id' +
+                    ' ON graphs_dim_1_nf.graph_id ='
+                    ' rational_preperiodic_dim_1_nf.graph_id' +
                     where_text
                 )
                 cur.execute(sql)

--- a/Backend/postgres_connector.py
+++ b/Backend/postgres_connector.py
@@ -106,8 +106,8 @@ class PostgresConnector:
         #    label, dimension, degree, polynomials, field_label
 
         columns = (
-            'function_id, sigma_one, sigma_two, ordinal,'
-            ' degree, (original_model).coeffs, base_field_label'
+            'functions_dim_1_nf.function_id, sigma_one, sigma_two, ordinal,'
+            ' degree, (original_model).coeffs, functions_dim_1_nf.base_field_label'
         )
         dims = filters['N']
         del filters['N']
@@ -118,11 +118,15 @@ class PostgresConnector:
             stats= self.get_statistics(where_text)
             result = []
             if dims == [] or 1 in dims:
-                sql = (
-                    'SELECT ' +
-                    columns +
-                    ' FROM functions_dim_1_NF' +
-                    where_text
+                sql = (f"""
+                    SELECT {columns}
+                    FROM functions_dim_1_nf
+                    JOIN rational_preperiodic_dim_1_nf
+                    ON functions_dim_1_nf.function_id = rational_preperiodic_dim_1_nf.function_id
+                    JOIN graphs_dim_1_nf
+                    ON graphs_dim_1_nf.graph_id = rational_preperiodic_dim_1_nf.graph_id
+                    {where_text}    
+                    """
                 )
                 with self.connection.cursor(
                     cursor_factory=psycopg2.extras.DictCursor
@@ -302,6 +306,12 @@ class PostgresConnector:
                 family = ARRAY{psycopg2.extensions.AsIs(values)}
                 """
                 conditions.append(query)
+                
+            elif fil in ['preperiodic_cardinality']:
+                conditions.append(f'cardinality = {values}')
+                
+            elif fil in ['num_components'] or fil in ['max_tail']:
+                conditions.append(f'{fil} = {values}')
 
             else:
                 conditions.append(

--- a/Backend/postgres_connector.py
+++ b/Backend/postgres_connector.py
@@ -230,6 +230,10 @@ class PostgresConnector:
                 sql = (
                     'SELECT COUNT( (original_model).height )'
                     ' FROM functions_dim_1_NF'
+                    ' JOIN rational_preperiodic_dim_1_nf'
+                    ' ON functions_dim_1_nf.function_id = rational_preperiodic_dim_1_nf.function_id'
+                    ' JOIN graphs_dim_1_nf'
+                    ' ON graphs_dim_1_nf.graph_id = rational_preperiodic_dim_1_nf.graph_id'
                     + where_text
                 )
                 cur.execute(sql)
@@ -238,6 +242,10 @@ class PostgresConnector:
                 sql = (
                     'SELECT AVG(automorphism_group_cardinality::int)'
                     ' FROM functions_dim_1_NF'
+                    ' JOIN rational_preperiodic_dim_1_nf'
+                    ' ON functions_dim_1_nf.function_id = rational_preperiodic_dim_1_nf.function_id'
+                    ' JOIN graphs_dim_1_nf'
+                    ' ON graphs_dim_1_nf.graph_id = rational_preperiodic_dim_1_nf.graph_id'
                     + where_text
                 )
                 cur.execute(sql)
@@ -245,6 +253,10 @@ class PostgresConnector:
                 # number of PCF
                 sql = (
                     'SELECT SUM(is_PCF::int) FROM functions_dim_1_NF'
+                    ' JOIN rational_preperiodic_dim_1_nf'
+                    ' ON functions_dim_1_nf.function_id = rational_preperiodic_dim_1_nf.function_id'
+                    ' JOIN graphs_dim_1_nf'
+                    ' ON graphs_dim_1_nf.graph_id = rational_preperiodic_dim_1_nf.graph_id'
                     + where_text
                 )
                 cur.execute(sql)
@@ -252,7 +264,11 @@ class PostgresConnector:
                 # Average Height
                 sql = (
                     'SELECT AVG( (original_model).height ) ' 
-                    'FROM functions_dim_1_NF' +
+                    'FROM functions_dim_1_NF' 
+                    ' JOIN rational_preperiodic_dim_1_nf'
+                    ' ON functions_dim_1_nf.function_id = rational_preperiodic_dim_1_nf.function_id'
+                    ' JOIN graphs_dim_1_nf'
+                    ' ON graphs_dim_1_nf.graph_id = rational_preperiodic_dim_1_nf.graph_id' +
                     where_text
                 )
                 cur.execute(sql)

--- a/Backend/postgres_connector.py
+++ b/Backend/postgres_connector.py
@@ -107,7 +107,8 @@ class PostgresConnector:
 
         columns = (
             'functions_dim_1_nf.function_id, sigma_one, sigma_two, ordinal,'
-            ' degree, (original_model).coeffs, functions_dim_1_nf.base_field_label'
+            ' degree, (original_model).coeffs, ' 
+            'functions_dim_1_nf.base_field_label'
         )
         dims = filters['N']
         del filters['N']
@@ -306,10 +307,10 @@ class PostgresConnector:
                 family = ARRAY{psycopg2.extensions.AsIs(values)}
                 """
                 conditions.append(query)
-                
+
             elif fil in ['preperiodic_cardinality']:
                 conditions.append(f'cardinality = {values}')
-                
+
             elif fil in ['num_components'] or fil in ['max_tail']:
                 conditions.append(f'{fil} = {values}')
 

--- a/Frontend/src/pages/ExploreSystems.js
+++ b/Frontend/src/pages/ExploreSystems.js
@@ -283,6 +283,9 @@ function ExploreSystems() {
         base_field_label: "",
         base_field_degree: "",
         indeterminacy_locus_dimension: ""
+        preperiodic_cardinality: "",
+        num_components: "",
+        max_tail: ""
     };
 
     let connectionStatus = true;

--- a/Frontend/src/pages/ExploreSystems.js
+++ b/Frontend/src/pages/ExploreSystems.js
@@ -178,7 +178,7 @@ function ExploreSystems() {
                     base_field_degree: filters.base_field_degree,
                     indeterminacy_locus_dimension: filters.indeterminacy_locus_dimension,
                     family: filters.family,
-                    preperiodic_cardinaity: filters.rationalPreperiodicCardinality,
+                    preperiodic_cardinality: filters.rationalPreperiodicCardinality,
                     num_components: filters.rationalPreperiodicComponents,
                     max_tail: filters.rationalPreperiodicLongestTail
                 }

--- a/Frontend/src/pages/ExploreSystems.js
+++ b/Frontend/src/pages/ExploreSystems.js
@@ -177,7 +177,10 @@ function ExploreSystems() {
                     base_field_label: filters.base_field_label,
                     base_field_degree: filters.base_field_degree,
                     indeterminacy_locus_dimension: filters.indeterminacy_locus_dimension,
-                    family: filters.family
+                    family: filters.family,
+                    preperiodic_cardinaity: filters.rationalPreperiodicCardinality,
+                    num_components: filters.rationalPreperiodicComponents,
+                    max_tail: filters.rationalPreperiodicLongestTail
                 }
             )
             setSystems(result.data['results']);

--- a/Frontend/src/pages/ExploreSystems.js
+++ b/Frontend/src/pages/ExploreSystems.js
@@ -282,7 +282,7 @@ function ExploreSystems() {
         automorphism_group_cardinality: "",
         base_field_label: "",
         base_field_degree: "",
-        indeterminacy_locus_dimension: ""
+        indeterminacy_locus_dimension: "",
         preperiodic_cardinality: "",
         num_components: "",
         max_tail: ""


### PR DESCRIPTION
Fixes #143 

**What was changed?**

Backend logic was added to the Rational Preperiodic Point filters so that the filters are functional.

**Why was it changed?**

Last sprint, the subfields for the Rational Preperiodic Point filter were added so that the user would be able to filter by subfields. However, the functionality of the filter was not implemented. So when the user would enter a value, it would appear everything worked however no data was actually filtered out. Therefore we had to implement the filtering on the backend in order to make those subfields functional.

**How was it changed?**

First I had to handle the passing between the front end and the back end so that the filters would actually pass information to the backend. This involved changing the `ExploreSystems.js` file to enable the handoff. I added keys to the filters in the `result` variable so that when the user pressed submit, those filters would be included in the function to pass the values into the back end. For the backend, the only file needing change was `postgres_connector.py`. First we had to change the base `sql` variable so that it included the columns we need to sort by. So we joined the tables `graphs_dim_1_nf` and `functions_dim_1_nf` via `rational_preperiodic_dim_1_nf` so that we could map the columns in `graphs_dim_1_nf` to the results in `functions_dim_1_nf`. This introduced a bug where we need to now specify what table columns `base_field_label` and `function_id` are in because there's now 2 columns with that name. Finally, we add cases to `build_where_text()` to accomadate queries for the new values and once done, the filter now works!

**Screenshots that show the changes (if applicable):**
