### PR TITLE
Fix cardinality sub filter for rational periodic point filter #142

### DIFF
--- a/Backend/postgres_connector.py
+++ b/Backend/postgres_connector.py
@@ -107,8 +107,8 @@ class PostgresConnector:
 
         columns = (
             'functions_dim_1_nf.function_id, sigma_one, sigma_two, ordinal,'
-            ' degree, (original_model).coeffs, ' 
-            'functions_dim_1_nf.base_field_label'
+            ' degree, (original_model).coeffs,'
+            ' functions_dim_1_nf.base_field_label'
         )
         dims = filters['N']
         del filters['N']
@@ -251,7 +251,7 @@ class PostgresConnector:
                 pcf = cur.fetchall()
                 # Average Height
                 sql = (
-                    'SELECT AVG( (original_model).height ) ' 
+                    'SELECT AVG( (original_model).height ) '
                     'FROM functions_dim_1_NF' +
                     where_text
                 )
@@ -308,13 +308,19 @@ class PostgresConnector:
                 """
                 conditions.append(query)
 
-            elif fil =='cp_cardinality':
-                conditions.append(f"{fil} = {int(values)}")
+            elif fil == 'cp_cardinality':
+                conditions.append(f'{fil} = {int(values)}')
+
 
             elif fil == 'periodic_cycles':
-                print(f"Filter value for periodic_cycles: {int(values)}")  # Log the filter value
-                conditions.append(f"(SELECT MAX(val) FROM unnest(graphs_dim_1_nf.periodic_cycles) AS val WHERE val IS NOT NULL) = {int(values)}")
-
+                print(
+                    f'Filter value for periodic_cycles: {int(values)}'
+                )  
+                conditions.append(
+    f'(SELECT MAX(val) FROM unnest(graphs_dim_1_nf.periodic_cycles) AS val '
+    f'WHERE val IS NOT NULL) = '
+    f'{int(values)}'
+)
             else:
                 conditions.append(
                     fil +

--- a/Backend/postgres_connector.py
+++ b/Backend/postgres_connector.py
@@ -315,7 +315,7 @@ class PostgresConnector:
             elif fil == 'periodic_cycles':
                 print(
                     f'Filter value for periodic_cycles: {int(values)}'
-                )  
+                )
                 conditions.append(
     f'(SELECT MAX(val) FROM unnest(graphs_dim_1_nf.periodic_cycles) AS val '
     f'WHERE val IS NOT NULL) = '

--- a/Backend/postgres_connector.py
+++ b/Backend/postgres_connector.py
@@ -107,7 +107,7 @@ class PostgresConnector:
 
         columns = (
             'functions_dim_1_nf.function_id, sigma_one, sigma_two, ordinal,'
-            ' degree, (original_model).coeffs, ' 
+            ' degree, (original_model).coeffs, '
             'functions_dim_1_nf.base_field_label'
         )
         dims = filters['N']
@@ -269,8 +269,8 @@ class PostgresConnector:
                 pcf = cur.fetchall()
                 # Average Height
                 sql = (
-                    'SELECT AVG( (original_model).height ) ' 
-                    'FROM functions_dim_1_NF' 
+                    'SELECT AVG( (original_model).height ) '
+                    'FROM functions_dim_1_NF'
                     ' JOIN rational_preperiodic_dim_1_nf'
                     ' ON functions_dim_1_nf.function_id ='
                     ' rational_preperiodic_dim_1_nf.function_id'
@@ -346,9 +346,9 @@ class PostgresConnector:
                     f'Filter value for periodic_cycles: {int(values)}'
                 )
                 conditions.append(
-                    f'(SELECT MAX(val) FROM unnest(graphs_dim_1_nf.periodic_cycles) AS val '
-                    f'WHERE val IS NOT NULL)='
-                    f'{int(values)}'
+f'(SELECT MAX(val) FROM unnest(graphs_dim_1_nf.periodic_cycles) AS val '
+f'WHERE val IS NOT NULL)='
+f'{int(values)}'
                 )
 
             else:

--- a/Backend/postgres_connector.py
+++ b/Backend/postgres_connector.py
@@ -303,6 +303,9 @@ class PostgresConnector:
                 """
                 conditions.append(query)
 
+            elif fil =='cp_cardinality':
+                conditions.append(fil + ' = ' + str(values))
+
             else:
                 conditions.append(
                     fil +

--- a/Frontend/src/context/FilterContext.js
+++ b/Frontend/src/context/FilterContext.js
@@ -21,7 +21,7 @@ export const FilterProvider = ({ children }) => {
         base_field_degree: "",
         indeterminacy_locus_dimension: "",
         cp_cardinality: "",
-        largest_cycle: ""
+        periodic_cycles: ""
     });
 
     return (

--- a/Frontend/src/context/FilterContext.js
+++ b/Frontend/src/context/FilterContext.js
@@ -19,7 +19,9 @@ export const FilterProvider = ({ children }) => {
         automorphism_group_cardinality: "",
         base_field_label: "",
         base_field_degree: "",
-        indeterminacy_locus_dimension: ""
+        indeterminacy_locus_dimension: "",
+        cp_cardinality: "",
+        largest_cycle: ""
     });
 
     return (

--- a/Frontend/src/pages/ExploreSystems.js
+++ b/Frontend/src/pages/ExploreSystems.js
@@ -173,6 +173,8 @@ function ExploreSystems() {
                     is_Chebyshev: filters.is_Chebyshev,
                     is_Newton: filters.is_Newton,
                     is_pcf: filters.is_pcf,
+                    cp_cardinality: filters.cp_cardinality || "",
+                    periodic_largest_cycle: filters.largest_cycle || "",
                     automorphism_group_cardinality: filters.automorphism_group_cardinality,
                     base_field_label: filters.base_field_label,
                     base_field_degree: filters.base_field_degree,
@@ -279,7 +281,9 @@ function ExploreSystems() {
         automorphism_group_cardinality: "",
         base_field_label: "",
         base_field_degree: "",
-        indeterminacy_locus_dimension: ""
+        indeterminacy_locus_dimension: "",
+        cp_cardinality: "",
+        largest_cycle: ""
     };
 
     let connectionStatus = true;
@@ -465,12 +469,16 @@ function ExploreSystems() {
                                         <input
                                             type="text"
                                             style={textBoxStyle}
+                                            value={filters.cp_cardinality || ""}
+                                            onChange={(e) => handleTextChange('cp_cardinality', e.target.value)}
                                         />
                                         <label>Cardinality</label>
                                         <br />
                                         <input
                                             type="text"
                                             style={textBoxStyle}
+                                            value={filters.largest_cycle || ""}
+                                            onChange={(e) => handleTextChange('largest_cycle', e.target.value)}
                                         />
                                         <label>Largest Cycle</label>
                                         <br />

--- a/Frontend/src/pages/ExploreSystems.js
+++ b/Frontend/src/pages/ExploreSystems.js
@@ -173,8 +173,8 @@ function ExploreSystems() {
                     is_Chebyshev: filters.is_Chebyshev,
                     is_Newton: filters.is_Newton,
                     is_pcf: filters.is_pcf,
-                    cp_cardinality: filters.cp_cardinality || "",
-                    periodic_largest_cycle: filters.largest_cycle || "",
+                    cp_cardinality: filters.cp_cardinality,
+                    periodic_cycles: (filters.periodic_cycles),
                     automorphism_group_cardinality: filters.automorphism_group_cardinality,
                     base_field_label: filters.base_field_label,
                     base_field_degree: filters.base_field_degree,
@@ -283,7 +283,7 @@ function ExploreSystems() {
         base_field_degree: "",
         indeterminacy_locus_dimension: "",
         cp_cardinality: "",
-        largest_cycle: ""
+        periodic_cycles: ""
     };
 
     let connectionStatus = true;
@@ -467,7 +467,7 @@ function ExploreSystems() {
                                     </span>
                                     <ul className="nested">
                                         <input
-                                            type="text"
+                                            type="number"
                                             style={textBoxStyle}
                                             value={filters.cp_cardinality || ""}
                                             onChange={(e) => handleTextChange('cp_cardinality', e.target.value)}
@@ -475,10 +475,10 @@ function ExploreSystems() {
                                         <label>Cardinality</label>
                                         <br />
                                         <input
-                                            type="text"
+                                            type="number"
                                             style={textBoxStyle}
-                                            value={filters.largest_cycle || ""}
-                                            onChange={(e) => handleTextChange('largest_cycle', e.target.value)}
+                                            value={filters.periodic_cycles || ""}
+                                            onChange={(e) => handleTextChange('periodic_cycles', e.target.value)}
                                         />
                                         <label>Largest Cycle</label>
                                         <br />


### PR DESCRIPTION
Fixes #142

**What was changed?**
The cardinality sub-filter under rational periodic points has been implemented.

*Here, describe what part of the application you changed (e.g. login page, database, etc.). If possible, mention what specific components were added, removed, or modified.*
Frontend: modified the filter handling for cp_cardinality so that the correct filter is passed from the UI.
Backend: Updated the database query logic to handle cp_cardinality correctly

**Why was it changed?**
This issue was changed so the users can more effectively filter the data they are searching for.

*Here, describe the issue that you are fixing with this code, and why your code fixes it.*
The cardinality filter under Rational Periodic Points was not functioning at all. It was returning all results regardless of the filter input. The fix is so that users can now filter this data based on the criteria.

**How was it changed?**
This code was changed by adjusting the filter logic of the Rational Periodic Point filter in both the frontend and backend as well as reviewing which database queries to implement.

*Here, get into detail about what files you modified, and talk about the most important lines in regards to fixing the issue.*
Added support to postgres_connector.py to filter by cp_cardinality in SQL queries. In FilterContext.js I added the cp_cardinality key to the filter context to pass the correct filter value to the backend. And in ExploreSystems.js the logic was modified to capture and send the cp_cardinality filter from the UI to the backend. 

Remaining Issue:
Largest cycle is still not implemented, I could not find where this data was being stored to be implemented

**Screenshots that show the changes (if applicable):**
