### PR TITLE
Remove tmp fields from function details page

### DIFF
--- a/Frontend/src/components/FunctionDetail/CriticalPointPortraitTable.js
+++ b/Frontend/src/components/FunctionDetail/CriticalPointPortraitTable.js
@@ -38,10 +38,6 @@ export default function CriticalPointPortraitTable({ data }) {
             <TableCell align="right">{formatData(data.critical_portrait_cardinality)}</TableCell>
           </TableRow>
           <TableRow>
-            <TableCell component="th" scope="row"><b>Cycle Sizes</b></TableCell>
-            <TableCell align="right">{"tmp"}</TableCell>
-          </TableRow>
-          <TableRow>
             <TableCell component="th" scope="row"><b>As Directed Graph (graph ID for now)</b></TableCell>
             <TableCell align="right">{formatData(data.critical_portrait_graph_id)}</TableCell>
           </TableRow>

--- a/Frontend/src/components/FunctionDetail/CriticalPointsTable.js
+++ b/Frontend/src/components/FunctionDetail/CriticalPointsTable.js
@@ -13,20 +13,8 @@ export default function CriticalPointsTable({ data }) {
       <Table aria-label="simple table">
         <TableBody>
           <TableRow>
-            <TableCell component="th" scope="row"><b>Cardinality</b></TableCell>
-            <TableCell align="right">{"tmp"}</TableCell>
-          </TableRow>
-          <TableRow>
             <TableCell component="th" scope="row"><b>Postcritically Finite?</b></TableCell>
             <TableCell align="right">{String(data.is_pcf)}</TableCell>
-          </TableRow>
-          <TableRow>
-            <TableCell component="th" scope="row"><b># Post Critical Set</b></TableCell>
-            <TableCell align="right">{"tmp"}</TableCell>
-          </TableRow>
-          <TableRow>
-            <TableCell component="th" scope="row"><b>Field of Definition</b></TableCell>
-            <TableCell align="right">{"tmp"}</TableCell>
           </TableRow>
         </TableBody>
       </Table>

--- a/Frontend/src/components/FunctionDetail/InfoTable.js
+++ b/Frontend/src/components/FunctionDetail/InfoTable.js
@@ -16,21 +16,13 @@ export default function InfoTable({ data }) {
             <TableCell><b>Label</b></TableCell>
             <TableCell align="right"><b>Domain</b></TableCell>
             <TableCell align="right"><b>Standard Model</b></TableCell>
-            <TableCell align="right"><b>Degree</b></TableCell>
-            <TableCell align="right"><b>Field of Definition</b></TableCell>
-            <TableCell align="right"><b>Min Field of Definition</b></TableCell>
-            <TableCell align="right"><b>Field of Modull</b></TableCell>
           </TableRow>
         </TableHead>
         <TableBody>
           <TableRow>
             <TableCell component="th" scope="row">{data.modelLabel}</TableCell>
             <TableCell align="right">{data.base_field_label}</TableCell>
-            <TableCell align="right">{"tmp"}</TableCell>
             <TableCell align="right">{data.degree}</TableCell>
-            <TableCell align="right">{"tmp"}</TableCell>
-            <TableCell align="right">{"tmp"}</TableCell>
-            <TableCell align="right">{"tmp"}</TableCell>
           </TableRow>
         </TableBody>
       </Table>


### PR DESCRIPTION
Fixes #159

**What was changed?**
Fields that display "tmp" were removed.

*Here, describe what part of the application you changed (e.g. login page, database, etc.). If possible, mention what specific components were added, removed, or modified.*
This changed the function details page by removing the fields Standard Model, Field of Definition, Min Field of Definition, Field of Modull, Cycle Sizes, Critical Points Cardinality, and Post Critical Set.

**Why was it changed?**
They were changed because they held the value "tmp"

*Here, describe the issue that you are fixing with this code, and why your code fixes it.*
This removes unnecessary data and provides only relevant fields with meaningful data to be more neatly displayed for the user.

**How was it changed?**
This was changed by deleting the unnecessary fields with value of "tmp".

*Here, get into detail about what files you modified, and talk about the most important lines in regards to fixing the issue.*
CriticalPointPortraitTable.js (lines 40-43), InfoTable.js (lines 19-22, 29-33), and CriticalPountsTable.js (lines 15-18, 23-30) were all modified by simply deleting the lines of code of certain fields with "tmp" hard-coded to display.

**Screenshots that show the changes (if applicable):**
