### PR TITLE
statistics page

### DIFF
--- a/Backend/postgres_connector.py
+++ b/Backend/postgres_connector.py
@@ -301,6 +301,39 @@ class PostgresConnector:
                 avg_pc_set = positive_in_degree_stats[0]
                 largeset_pc_set = positive_in_degree_stats[1]
 
+                sql = (
+                    'SELECT periodic_cardinality'
+                    ' FROM graphs_dim_1_nf'
+                    ' JOIN rational_preperiodic_dim_1_nf'
+                    ' ON graphs_dim_1_nf.graph_id = rational_preperiodic_dim_1_nf.graph_id'
+                    ' JOIN functions_dim_1_nf'
+                    ' ON functions_dim_1_nf.function_id = rational_preperiodic_dim_1_nf.function_id'
+                    + where_text
+                )
+                cur.execute(sql)
+                periodic_cardinalities = [row[0] for row in cur.fetchall()]
+
+                avg_num_periodic = sum(periodic_cardinalities) / len(periodic_cardinalities)
+                most_periodic = max(set(periodic_cardinalities), key=periodic_cardinalities.count)
+                largest_cycle = max(periodic_cardinalities)
+
+                sql = (
+                    'SELECT preperiodic_components'
+                    ' FROM graphs_dim_1_nf'
+                    ' JOIN rational_preperiodic_dim_1_nf'
+                    ' ON graphs_dim_1_nf.graph_id = rational_preperiodic_dim_1_nf.graph_id'
+                    ' JOIN functions_dim_1_nf'
+                    ' ON functions_dim_1_nf.function_id = rational_preperiodic_dim_1_nf.function_id'
+                    + where_text
+                )
+                cur.execute(sql)
+                preperiodic_components = [row[0] for row in cur.fetchall()]
+
+                avg_num_preperiodic = sum(len(comp) for comp in preperiodic_components) / len(preperiodic_components)
+                component_sizes = [len(comp) for comp in preperiodic_components]
+                most_preperiodic = max(set(component_sizes), key=component_sizes.count)
+                largest_comp = max(component_sizes)
+
         except Exception:
             self.connection.rollback()
             maps = 0
@@ -310,7 +343,16 @@ class PostgresConnector:
             resultant = 0
             avg_pc_set = 0
             largeset_pc_set = 0
-        return [maps, aut, pcf, height, resultant, avg_pc_set, largeset_pc_set]
+            avg_num_periodic = 0
+            most_periodic = 0
+            largest_cycle = 0
+            most_preperiodic = 0
+            largest_comp = 0
+        return [maps, aut, pcf, height, resultant, 
+                avg_pc_set, largeset_pc_set, 
+                avg_num_periodic, most_periodic, 
+                largest_cycle, avg_num_preperiodic,
+                most_preperiodic, largest_comp]
 
     def build_where_text(self, filters):
         # remove empty filters

--- a/Backend/postgres_connector.py
+++ b/Backend/postgres_connector.py
@@ -193,6 +193,7 @@ class PostgresConnector:
             if cur:
                 cur.close()
 
+        print("results/stats", result, stats)
         return result,stats
 
     # gets a subset of the systems identified by the labels
@@ -281,7 +282,25 @@ class PostgresConnector:
                 )
                 cur.execute(sql)
                 height = cur.fetchall()
+                print("the height is: ", height)
                 resultant = 0
+
+                sql = (
+                    'SELECT '
+                    'AVG(positive_in_degree) AS avg_positive_in_degree, '
+                    'MAX(positive_in_degree) AS max_positive_in_degree '
+                    'FROM graphs_dim_1_nf '
+                    'JOIN rational_preperiodic_dim_1_nf '
+                    'ON graphs_dim_1_nf.graph_id = rational_preperiodic_dim_1_nf.graph_id '
+                    'JOIN functions_dim_1_nf '
+                    'ON functions_dim_1_nf.function_id = rational_preperiodic_dim_1_nf.function_id'
+                    + where_text
+                )
+                cur.execute(sql)
+                positive_in_degree_stats = cur.fetchone()
+                average_pc_set = positive_in_degree_stats[0]
+                largeset_pc_set = positive_in_degree_stats[1]
+
         except Exception:
             self.connection.rollback()
             maps = 0
@@ -289,7 +308,9 @@ class PostgresConnector:
             pcf = 0
             height = 0
             resultant = 0
-        return [maps, aut, pcf, height, resultant]
+            average_pc_set = 0
+            largeset_pc_set = 0
+        return [maps, aut, pcf, height, resultant, average_pc_set, largeset_pc_set]
 
     def build_where_text(self, filters):
         # remove empty filters

--- a/Backend/postgres_connector.py
+++ b/Backend/postgres_connector.py
@@ -289,9 +289,11 @@ class PostgresConnector:
                     'MAX(positive_in_degree) AS max_positive_in_degree '
                     'FROM graphs_dim_1_nf '
                     'JOIN rational_preperiodic_dim_1_nf '
-                    'ON graphs_dim_1_nf.graph_id = rational_preperiodic_dim_1_nf.graph_id '
+                    'ON graphs_dim_1_nf.graph_id = '
+                    'rational_preperiodic_dim_1_nf.graph_id '
                     'JOIN functions_dim_1_nf '
-                    'ON functions_dim_1_nf.function_id = rational_preperiodic_dim_1_nf.function_id'
+                    'ON functions_dim_1_nf.function_id = '
+                    'rational_preperiodic_dim_1_nf.function_id'
                     + where_text
                 )
                 cur.execute(sql)

--- a/Backend/postgres_connector.py
+++ b/Backend/postgres_connector.py
@@ -296,7 +296,7 @@ class PostgresConnector:
                 )
                 cur.execute(sql)
                 positive_in_degree_stats = cur.fetchone()
-                average_pc_set = positive_in_degree_stats[0]
+                avg_pc_set = positive_in_degree_stats[0]
                 largeset_pc_set = positive_in_degree_stats[1]
 
         except Exception:
@@ -306,9 +306,9 @@ class PostgresConnector:
             pcf = 0
             height = 0
             resultant = 0
-            average_pc_set = 0
+            avg_pc_set = 0
             largeset_pc_set = 0
-        return [maps, aut, pcf, height, resultant, average_pc_set, largeset_pc_set]
+        return [maps, aut, pcf, height, resultant, avg_pc_set, largeset_pc_set]
 
     def build_where_text(self, filters):
         # remove empty filters

--- a/Backend/postgres_connector.py
+++ b/Backend/postgres_connector.py
@@ -305,34 +305,45 @@ class PostgresConnector:
                     'SELECT periodic_cardinality'
                     ' FROM graphs_dim_1_nf'
                     ' JOIN rational_preperiodic_dim_1_nf'
-                    ' ON graphs_dim_1_nf.graph_id = rational_preperiodic_dim_1_nf.graph_id'
+                    ' ON graphs_dim_1_nf.graph_id = '
+                    'rational_preperiodic_dim_1_nf.graph_id'
                     ' JOIN functions_dim_1_nf'
-                    ' ON functions_dim_1_nf.function_id = rational_preperiodic_dim_1_nf.function_id'
+                    ' ON functions_dim_1_nf.function_id = '
+                    'rational_preperiodic_dim_1_nf.function_id'
                     + where_text
                 )
                 cur.execute(sql)
                 periodic_cardinalities = [row[0] for row in cur.fetchall()]
-
-                avg_num_periodic = sum(periodic_cardinalities) / len(periodic_cardinalities)
-                most_periodic = max(set(periodic_cardinalities), key=periodic_cardinalities.count)
+                avg_num_periodic = sum(periodic_cardinalities) / len(
+                    periodic_cardinalities)
+                most_periodic = max(
+                    set(periodic_cardinalities),
+                    key=periodic_cardinalities.count
+                )
                 largest_cycle = max(periodic_cardinalities)
-
                 sql = (
                     'SELECT preperiodic_components'
                     ' FROM graphs_dim_1_nf'
                     ' JOIN rational_preperiodic_dim_1_nf'
-                    ' ON graphs_dim_1_nf.graph_id = rational_preperiodic_dim_1_nf.graph_id'
+                    ' ON graphs_dim_1_nf.graph_id = '
+                    'rational_preperiodic_dim_1_nf.graph_id'
                     ' JOIN functions_dim_1_nf'
-                    ' ON functions_dim_1_nf.function_id = rational_preperiodic_dim_1_nf.function_id'
+                    ' ON functions_dim_1_nf.function_id = '
+                    'rational_preperiodic_dim_1_nf.function_id'
                     + where_text
                 )
                 cur.execute(sql)
                 preperiodic_components = [row[0] for row in cur.fetchall()]
-
-                avg_num_preperiodic = sum(len(comp) for comp in preperiodic_components) / len(preperiodic_components)
+                avg_num_preperiodic = sum(
+                    len(comp) for comp in preperiodic_components
+                ) / len(preperiodic_components)
                 component_sizes = [len(comp) for comp in preperiodic_components]
-                most_preperiodic = max(set(component_sizes), key=component_sizes.count)
+                most_preperiodic = max(
+                    set(component_sizes),
+                    key=component_sizes.count
+                )
                 largest_comp = max(component_sizes)
+
 
         except Exception:
             self.connection.rollback()
@@ -342,15 +353,11 @@ class PostgresConnector:
             height = 0
             resultant = 0
             avg_pc_set = 0
-            largeset_pc_set = 0
-            avg_num_periodic = 0
-            most_periodic = 0
-            largest_cycle = 0
-            most_preperiodic = 0
-            largest_comp = 0
-        return [maps, aut, pcf, height, resultant, 
-                avg_pc_set, largeset_pc_set, 
-                avg_num_periodic, most_periodic, 
+            avg_num_periodic = most_periodic = largest_cycle = 0
+            avg_num_preperiodic = most_preperiodic = largest_comp = 0
+        return [maps, aut, pcf, height, resultant,
+                avg_pc_set, largeset_pc_set,
+                avg_num_periodic, most_periodic,
                 largest_cycle, avg_num_preperiodic,
                 most_preperiodic, largest_comp]
 

--- a/Backend/postgres_connector.py
+++ b/Backend/postgres_connector.py
@@ -193,7 +193,6 @@ class PostgresConnector:
             if cur:
                 cur.close()
 
-        print("results/stats", result, stats)
         return result,stats
 
     # gets a subset of the systems identified by the labels
@@ -282,7 +281,6 @@ class PostgresConnector:
                 )
                 cur.execute(sql)
                 height = cur.fetchall()
-                print("the height is: ", height)
                 resultant = 0
 
                 sql = (

--- a/Frontend/src/pages/ExploreSystems.js
+++ b/Frontend/src/pages/ExploreSystems.js
@@ -775,7 +775,7 @@ function ExploreSystems() {
 
                             <div className="statcontainer">
                                 <ul id="myUL">
-                                    <li><span className="caret" onClick={toggleTree}>Average #Periodic: {stats.avgNumPeriodic}</span>
+                                    <li><span className="caret" onClick={toggleTree}>Avg #Periodic: {stats.avgNumPeriodic}</span>
                                         <ul className="nested">
                                             <label>Most Periodic: {stats.mostPeriodic}</label>
                                             <br />
@@ -788,7 +788,7 @@ function ExploreSystems() {
 
                             <div className='statcontainer'>
                                 <ul id="myUL">
-                                    <li><span className="caret" onClick={toggleTree}>Average #Preperiodic: {stats.avgNumPrePeriodic}</span>
+                                    <li><span className="caret" onClick={toggleTree}>Avg #Preperiodic: {stats.avgNumPrePeriodic}</span>
                                         <ul className="nested">
                                             <label>Most Preperiodic: {stats.mostPreperiodic} </label>
                                             <br />

--- a/Frontend/src/pages/ExploreSystems.js
+++ b/Frontend/src/pages/ExploreSystems.js
@@ -195,7 +195,13 @@ function ExploreSystems() {
                         avgHeight: Math.round(result.data['statistics'][3] * 100) / 100, 
                         avgResultant: Math.round(result.data['statistics'][4] * 100) / 100, 
                         avgPCSet: Math.round(result.data['statistics'][5] * 100) / 100, 
-                        largestPCSet: result.data['statistics'][6] 
+                        largestPCSet: result.data['statistics'][6],
+                        avgNumPeriodic: Math.round(result.data['statistics'][7] * 100) / 100,
+                        mostPeriodic: result.data['statistics'][8],
+                        largestPeriodicCycle: result.data['statistics'][9],
+                        avgNumPrePeriodic: Math.round(result.data['statistics'][10] * 100) / 100,
+                        mostPreperiodic: result.data['statistics'][11],
+                        largestComp: result.data['statistics'][12]
                     }
             }))
         } catch (error) {
@@ -769,11 +775,11 @@ function ExploreSystems() {
 
                             <div className="statcontainer">
                                 <ul id="myUL">
-                                    <li><span className="caret" onClick={toggleTree}>Average #Periodic</span>
+                                    <li><span className="caret" onClick={toggleTree}>Average #Periodic: {stats.avgNumPeriodic}</span>
                                         <ul className="nested">
-                                            <label>Most Periodic</label>
+                                            <label>Most Periodic: {stats.mostPeriodic}</label>
                                             <br />
-                                            <label>Largest Cycle</label>
+                                            <label>Largest Cycle: {stats.largestPeriodicCycle}</label>
                                             <br />
                                         </ul>
                                     </li>
@@ -782,11 +788,11 @@ function ExploreSystems() {
 
                             <div className='statcontainer'>
                                 <ul id="myUL">
-                                    <li><span className="caret" onClick={toggleTree}>Average #Preperiodic</span>
+                                    <li><span className="caret" onClick={toggleTree}>Average #Preperiodic: {stats.avgNumPrePeriodic}</span>
                                         <ul className="nested">
-                                            <label>Most Preperiodic </label>
+                                            <label>Most Preperiodic: {stats.mostPreperiodic} </label>
                                             <br />
-                                            <label>Largest Comp.</label>
+                                            <label>Largest Comp.: {stats.largestComp}</label>
                                             <br />
                                         </ul>
                                     </li>

--- a/Frontend/src/pages/ExploreSystems.js
+++ b/Frontend/src/pages/ExploreSystems.js
@@ -188,7 +188,15 @@ function ExploreSystems() {
             setSystems(result.data['results']);
             setFiltersApplied({...filters})
             setStat((previousState => {
-                return { ...previousState, numMaps: result.data['statistics'][0], avgAUT: Math.round(result.data['statistics'][1] * 100) / 100, numPCF: result.data['statistics'][2], avgHeight: Math.round(result.data['statistics'][3] * 100) / 100, avgResultant: Math.round(result.data['statistics'][4] * 100) / 100 }
+                return { ...previousState, 
+                        numMaps: result.data['statistics'][0], 
+                        avgAUT: Math.round(result.data['statistics'][1] * 100) / 100, 
+                        numPCF: result.data['statistics'][2], 
+                        avgHeight: Math.round(result.data['statistics'][3] * 100) / 100, 
+                        avgResultant: Math.round(result.data['statistics'][4] * 100) / 100, 
+                        avgPCSet: Math.round(result.data['statistics'][5] * 100) / 100, 
+                        largestPCSet: result.data['statistics'][6] 
+                    }
             }))
         } catch (error) {
             setSystems(null);
@@ -746,11 +754,12 @@ function ExploreSystems() {
                                 <ul id="myUL">
                                     <li>
                                         <label className="caret" onClick={toggleTree}>Number PCF</label>
-
                                         <ul className="nested">
-                                            <label>Average Size of PC Set</label>
+                                            <label>Avg Size of PC Set: </label>
+                                            {stats.avgPCSet}
                                             <br />
-                                            <label>Largest PC Set</label>
+                                            <label>Largest PC Set: </label>
+                                            {stats.largestPCSet}
                                             <br />
                                         </ul>
                                     </li>


### PR DESCRIPTION
Fixes #146
What was changed?
The get_statistics() method in the PostgresConnector class was modified to include new statistics about the positive_in_degree column from the graphs_dim_1_nf table.
Why was it changed?
This change was implemented to provide more comprehensive statistics about the graphs in the database. Specifically, it adds information about the average and maximum positive in-degree of the graphs, which can be useful for analyzing the structure and complexity of the graphs in the system.
How was it changed?
The following changes were made to the postgres_connector.py file:

A new SQL query was added to the get_statistics() method to calculate the average and maximum positive_in_degree:

pythonCopysql = (
    'SELECT '
    'AVG(positive_in_degree) AS avg_positive_in_degree, '
    'MAX(positive_in_degree) AS max_positive_in_degree '
    'FROM graphs_dim_1_nf '
    'JOIN rational_preperiodic_dim_1_nf '
    'ON graphs_dim_1_nf.graph_id = rational_preperiodic_dim_1_nf.graph_id '
    'JOIN functions_dim_1_nf '
    'ON functions_dim_1_nf.function_id = rational_preperiodic_dim_1_nf.function_id'
    + where_text
)

New variables were added to store the results:

pythonCopyavg_positive_in_degree = 0
max_positive_in_degree = 0

The query execution and result assignment were added:

pythonCopycur.execute(sql)
positive_in_degree_stats = cur.fetchone()
avg_positive_in_degree = positive_in_degree_stats[0]
max_positive_in_degree = positive_in_degree_stats[1]

The return statement of the get_statistics() method was updated to include the new statistics:

pythonCopyreturn [maps, aut, pcf, height, resultant, avg_positive_in_degree, max_positive_in_degree]
These changes maintain the existing code style and structure while adding new functionality to provide more comprehensive graph statistics.