### PR TITLE
Fixing Filter and adding recommended changes

### DIFF
--- a/Backend/postgres_connector.py
+++ b/Backend/postgres_connector.py
@@ -363,9 +363,10 @@ class PostgresConnector:
                     f'Filter value for periodic_cycles: {int(values)}'
                 )
                 conditions.append(
-                    f'(SELECT MAX(val) FROM unnest(graphs_dim_1_nf.periodic_cycles) AS val '
-                    + f'WHERE val IS NOT NULL)='
-                    + f'{int(values)}'
+                    '(SELECT MAX(val) '
+                    'FROM unnest(graphs_dim_1_nf.periodic_cycles) AS val '
+                    'WHERE val IS NOT NULL)='
+                    f'{int(values)}'
                 )
             elif fil in ['cp_cardinality']:
                 conditions.append(f'{fil}={int(values)}')

--- a/Backend/postgres_connector.py
+++ b/Backend/postgres_connector.py
@@ -285,20 +285,70 @@ class PostgresConnector:
                 )
                 cur.execute(sql)
                 height = cur.fetchall()
-                # Average Resultant
+                resultant = 0
+
                 sql = (
-                    'SELECT AVG( (original_model).height ) '
-                    'FROM functions_dim_1_NF'
-                    ' JOIN rational_preperiodic_dim_1_nf'
-                    ' ON functions_dim_1_nf.function_id ='
-                    ' rational_preperiodic_dim_1_nf.function_id'
-                    ' JOIN graphs_dim_1_nf'
-                    ' ON graphs_dim_1_nf.graph_id ='
-                    ' rational_preperiodic_dim_1_nf.graph_id' +
-                    where_text
+                    'SELECT '
+                    'AVG(positive_in_degree) AS avg_positive_in_degree, '
+                    'MAX(positive_in_degree) AS max_positive_in_degree '
+                    'FROM graphs_dim_1_nf '
+                    'JOIN rational_preperiodic_dim_1_nf '
+                    'ON graphs_dim_1_nf.graph_id = '
+                    'rational_preperiodic_dim_1_nf.graph_id '
+                    'JOIN functions_dim_1_nf '
+                    'ON functions_dim_1_nf.function_id = '
+                    'rational_preperiodic_dim_1_nf.function_id'
+                    + where_text
                 )
                 cur.execute(sql)
-                resultant = cur.fetchall()
+                positive_in_degree_stats = cur.fetchone()
+                avg_pc_set = positive_in_degree_stats[0]
+                largeset_pc_set = positive_in_degree_stats[1]
+
+                sql = (
+                    'SELECT periodic_cardinality'
+                    ' FROM graphs_dim_1_nf'
+                    ' JOIN rational_preperiodic_dim_1_nf'
+                    ' ON graphs_dim_1_nf.graph_id = '
+                    'rational_preperiodic_dim_1_nf.graph_id'
+                    ' JOIN functions_dim_1_nf'
+                    ' ON functions_dim_1_nf.function_id = '
+                    'rational_preperiodic_dim_1_nf.function_id'
+                    + where_text
+                )
+                cur.execute(sql)
+                periodic_cardinalities = [row[0] for row in cur.fetchall()]
+                avg_num_periodic = sum(periodic_cardinalities) / len(
+                    periodic_cardinalities)
+                most_periodic = max(
+                    set(periodic_cardinalities),
+                    key=periodic_cardinalities.count
+                )
+                largest_cycle = max(periodic_cardinalities)
+                sql = (
+                    'SELECT preperiodic_components'
+                    ' FROM graphs_dim_1_nf'
+                    ' JOIN rational_preperiodic_dim_1_nf'
+                    ' ON graphs_dim_1_nf.graph_id = '
+                    'rational_preperiodic_dim_1_nf.graph_id'
+                    ' JOIN functions_dim_1_nf'
+                    ' ON functions_dim_1_nf.function_id = '
+                    'rational_preperiodic_dim_1_nf.function_id'
+                    + where_text
+                )
+                cur.execute(sql)
+                preperiodic_components = [row[0] for row in cur.fetchall()]
+                avg_num_preperiodic = sum(
+                    len(comp) for comp in preperiodic_components
+                ) / len(preperiodic_components)
+                component_sizes = [len(comp) for comp in preperiodic_components]
+                most_preperiodic = max(
+                    set(component_sizes),
+                    key=component_sizes.count
+                )
+                largest_comp = max(component_sizes)
+
+
         except Exception:
             self.connection.rollback()
             maps = 0
@@ -306,7 +356,14 @@ class PostgresConnector:
             pcf = 0
             height = 0
             resultant = 0
-        return [maps, aut, pcf, height, resultant]
+            avg_pc_set = 0
+            avg_num_periodic = most_periodic = largest_cycle = 0
+            avg_num_preperiodic = most_preperiodic = largest_comp = 0
+        return [maps, aut, pcf, height, resultant,
+                avg_pc_set, largeset_pc_set,
+                avg_num_periodic, most_periodic,
+                largest_cycle, avg_num_preperiodic,
+                most_preperiodic, largest_comp]
 
     def build_where_text(self, filters):
         # remove empty filters

--- a/Frontend/src/pages/ExploreSystems.js
+++ b/Frontend/src/pages/ExploreSystems.js
@@ -190,21 +190,21 @@ function ExploreSystems() {
             setSystems(result.data['results']);
             setFiltersApplied({...filters})
             setStat((previousState => {
-            return { ...previousState, 
-                    numMaps: result.data['statistics'][0], 
-                    avgAUT: Math.round(result.data['statistics'][1] * 100) / 100, 
-                    numPCF: result.data['statistics'][2], 
-                    avgHeight: Math.round(result.data['statistics'][3] * 100) / 100, 
-                    avgResultant: Math.round(result.data['statistics'][4] * 100) / 100, 
-                    avgPCSet: Math.round(result.data['statistics'][5] * 100) / 100, 
-                    largestPCSet: result.data['statistics'][6],
-                    avgNumPeriodic: Math.round(result.data['statistics'][7] * 100) / 100,
-                    mostPeriodic: result.data['statistics'][8],
-                    largestPeriodicCycle: result.data['statistics'][9],
-                    avgNumPrePeriodic: Math.round(result.data['statistics'][10] * 100) / 100,
-                    mostPreperiodic: result.data['statistics'][11],
-                    largestComp: result.data['statistics'][12]
-                }
+                return { ...previousState, 
+                        numMaps: result.data['statistics'][0], 
+                        avgAUT: Math.round(result.data['statistics'][1] * 100) / 100, 
+                        numPCF: result.data['statistics'][2], 
+                        avgHeight: Math.round(result.data['statistics'][3] * 100) / 100, 
+                        avgResultant: Math.round(result.data['statistics'][4] * 100) / 100, 
+                        avgPCSet: Math.round(result.data['statistics'][5] * 100) / 100, 
+                        largestPCSet: result.data['statistics'][6],
+                        avgNumPeriodic: Math.round(result.data['statistics'][7] * 100) / 100,
+                        mostPeriodic: result.data['statistics'][8],
+                        largestPeriodicCycle: result.data['statistics'][9],
+                        avgNumPrePeriodic: Math.round(result.data['statistics'][10] * 100) / 100,
+                        mostPreperiodic: result.data['statistics'][11],
+                        largestComp: result.data['statistics'][12]
+                    }
             }))
         } catch (error) {
             setSystems(null);
@@ -779,10 +779,10 @@ function ExploreSystems() {
                                         <label className="caret" onClick={toggleTree}>Number PCF</label>
 
                                         <ul className="nested">
-                                            <label>Avg Size of PC Set:</label>
+                                            <label>Avg Size of PC Set: </label>
                                             {stats.avgPCSet}
                                             <br />
-                                            <label>Largest PC Set:</label>
+                                            <label>Largest PC Set: </label>
                                             {stats.largestPCSet}
                                             <br />
                                         </ul>

--- a/Frontend/src/pages/ExploreSystems.js
+++ b/Frontend/src/pages/ExploreSystems.js
@@ -190,21 +190,21 @@ function ExploreSystems() {
             setSystems(result.data['results']);
             setFiltersApplied({...filters})
             setStat((previousState => {
-			return { ...previousState, 
-					numMaps: result.data['statistics'][0], 
-					avgAUT: Math.round(result.data['statistics'][1] * 100) / 100, 
-					numPCF: result.data['statistics'][2], 
-					avgHeight: Math.round(result.data['statistics'][3] * 100) / 100, 
-					avgResultant: Math.round(result.data['statistics'][4] * 100) / 100, 
-					avgPCSet: Math.round(result.data['statistics'][5] * 100) / 100, 
-					largestPCSet: result.data['statistics'][6],
-					avgNumPeriodic: Math.round(result.data['statistics'][7] * 100) / 100,
-					mostPeriodic: result.data['statistics'][8],
-					largestPeriodicCycle: result.data['statistics'][9],
-					avgNumPrePeriodic: Math.round(result.data['statistics'][10] * 100) / 100,
-					mostPreperiodic: result.data['statistics'][11],
-					largestComp: result.data['statistics'][12]
-				}
+            return { ...previousState, 
+                    numMaps: result.data['statistics'][0], 
+                    avgAUT: Math.round(result.data['statistics'][1] * 100) / 100, 
+                    numPCF: result.data['statistics'][2], 
+                    avgHeight: Math.round(result.data['statistics'][3] * 100) / 100, 
+                    avgResultant: Math.round(result.data['statistics'][4] * 100) / 100, 
+                    avgPCSet: Math.round(result.data['statistics'][5] * 100) / 100, 
+                    largestPCSet: result.data['statistics'][6],
+                    avgNumPeriodic: Math.round(result.data['statistics'][7] * 100) / 100,
+                    mostPeriodic: result.data['statistics'][8],
+                    largestPeriodicCycle: result.data['statistics'][9],
+                    avgNumPrePeriodic: Math.round(result.data['statistics'][10] * 100) / 100,
+                    mostPreperiodic: result.data['statistics'][11],
+                    largestComp: result.data['statistics'][12]
+                }
             }))
         } catch (error) {
             setSystems(null);
@@ -779,10 +779,10 @@ function ExploreSystems() {
                                         <label className="caret" onClick={toggleTree}>Number PCF</label>
 
                                         <ul className="nested">
-                                            <label>Average Size of PC Set</label>
+                                            <label>Avg Size of PC Set:</label>
                                             {stats.avgPCSet}
                                             <br />
-                                            <label>Largest PC Set</label>
+                                            <label>Largest PC Set:</label>
                                             {stats.largestPCSet}
                                             <br />
                                         </ul>
@@ -793,7 +793,7 @@ function ExploreSystems() {
 
                             <div className="statcontainer">
                                 <ul id="myUL">
-                                    <li><span className="caret" onClick={toggleTree}>Average #Periodic: {stats.avgNumPeriodic}</span>
+                                    <li><span className="caret" onClick={toggleTree}>Avg #Periodic: {stats.avgNumPeriodic}</span>
                                         <ul className="nested">
                                             <label>Most Periodic: {stats.mostPeriodic}</label>
                                             <br />
@@ -806,7 +806,7 @@ function ExploreSystems() {
 
                             <div className='statcontainer'>
                                 <ul id="myUL">
-                                    <li><span className="caret" onClick={toggleTree}>Average #Preperiodic: {stats.avgNumPrePeriodic}</span>
+                                    <li><span className="caret" onClick={toggleTree}>Avg #Preperiodic: {stats.avgNumPrePeriodic}</span>
                                         <ul className="nested">
                                             <label>Most Preperiodic: {stats.mostPreperiodic} </label>
                                             <br />

--- a/Frontend/src/pages/ExploreSystems.js
+++ b/Frontend/src/pages/ExploreSystems.js
@@ -173,7 +173,7 @@ function ExploreSystems() {
                     is_Chebyshev: filters.is_Chebyshev,
                     is_Newton: filters.is_Newton,
                     is_pcf: filters.is_pcf,
-                    cp_cardinality: filters.cp_cardinality,
+                    periodic_cardinality: filters.periodic_cardinality,
                     periodic_cycles: (filters.periodic_cycles),
                     automorphism_group_cardinality: filters.automorphism_group_cardinality,
                     base_field_label: filters.base_field_label,
@@ -182,27 +182,15 @@ function ExploreSystems() {
                     family: filters.family,
                     preperiodic_cardinality: filters.rationalPreperiodicCardinality,
                     num_components: filters.rationalPreperiodicComponents,
-                    max_tail: filters.rationalPreperiodicLongestTail
+                    max_tail: filters.rationalPreperiodicLongestTail,
+                    cp_cardinality: filters.cp_cardinality,
+                    positive_in_degree: filters.positive_in_degree
                 }
             )
             setSystems(result.data['results']);
             setFiltersApplied({...filters})
             setStat((previousState => {
-                return { ...previousState, 
-                        numMaps: result.data['statistics'][0], 
-                        avgAUT: Math.round(result.data['statistics'][1] * 100) / 100, 
-                        numPCF: result.data['statistics'][2], 
-                        avgHeight: Math.round(result.data['statistics'][3] * 100) / 100, 
-                        avgResultant: Math.round(result.data['statistics'][4] * 100) / 100, 
-                        avgPCSet: Math.round(result.data['statistics'][5] * 100) / 100, 
-                        largestPCSet: result.data['statistics'][6],
-                        avgNumPeriodic: Math.round(result.data['statistics'][7] * 100) / 100,
-                        mostPeriodic: result.data['statistics'][8],
-                        largestPeriodicCycle: result.data['statistics'][9],
-                        avgNumPrePeriodic: Math.round(result.data['statistics'][10] * 100) / 100,
-                        mostPreperiodic: result.data['statistics'][11],
-                        largestComp: result.data['statistics'][12]
-                    }
+                return { ...previousState, numMaps: result.data['statistics'][0], avgAUT: Math.round(result.data['statistics'][1] * 100) / 100, numPCF: result.data['statistics'][2], avgHeight: Math.round(result.data['statistics'][3] * 100) / 100, avgResultant: Math.round(result.data['statistics'][4] * 100) / 100 }
             }))
         } catch (error) {
             setSystems(null);
@@ -294,11 +282,13 @@ function ExploreSystems() {
         base_field_label: "",
         base_field_degree: "",
         indeterminacy_locus_dimension: "",
-        cp_cardinality: "",
+        periodic_cardinality: "",
         periodic_cycles: "",
         preperiodic_cardinality: "",
         num_components: "",
-        max_tail: ""
+        max_tail: "",
+        cp_cardinality: "",
+        positive_in_degree: ""
     };
 
     let connectionStatus = true;
@@ -484,8 +474,8 @@ function ExploreSystems() {
                                         <input
                                             type="number"
                                             style={textBoxStyle}
-                                            value={filters.cp_cardinality || ""}
-                                            onChange={(e) => handleTextChange('cp_cardinality', e.target.value)}
+                                            value={filters.periodic_cardinality || ""}
+                                            onChange={(e) => handleTextChange('periodic_cardinality', e.target.value)}
                                         />
                                         <label>Cardinality</label>
                                         <br />
@@ -564,7 +554,7 @@ function ExploreSystems() {
 
                             <ul id="myUL">
                                 <li>
-                                    <span className="caret" onClick={toggleTree}>Postcritically Finite</span>
+                                    <span className="caret" onClick={toggleTree}>Critical Points</span>
                                     <ul className="nested">
                                         <li>
                                             <input
@@ -598,6 +588,24 @@ function ExploreSystems() {
                                                 onChange={() => handleRadioChange('is_pcf', '')}
                                             />
                                             <label htmlFor="showAll">Show all</label>
+                                        </li>
+                                        <li>
+                                        <input
+                                            type="number"
+                                            style={textBoxStyle}
+                                            value={filters.positive_in_degree || ''}
+                                            onChange={(e) => handleTextChange("positive_in_degree", e.target.value)}
+                                        />
+                                        <label>Post Critical Cardinality</label>
+                                        </li>
+                                        <li>
+                                        <input
+                                            type="number"
+                                            style={textBoxStyle}
+                                            value={filters.cp_cardinality || ''}
+                                            onChange={(e) => handleTextChange("cp_cardinality", e.target.value)}
+                                        />
+                                        <label>Num. Critical Points</label>
                                         </li>
                                     </ul>
                                 </li>
@@ -755,12 +763,11 @@ function ExploreSystems() {
                                 <ul id="myUL">
                                     <li>
                                         <label className="caret" onClick={toggleTree}>Number PCF</label>
+
                                         <ul className="nested">
-                                            <label>Avg Size of PC Set: </label>
-                                            {stats.avgPCSet}
+                                            <label>Average Size of PC Set</label>
                                             <br />
-                                            <label>Largest PC Set: </label>
-                                            {stats.largestPCSet}
+                                            <label>Largest PC Set</label>
                                             <br />
                                         </ul>
                                     </li>
@@ -770,11 +777,11 @@ function ExploreSystems() {
 
                             <div className="statcontainer">
                                 <ul id="myUL">
-                                    <li><span className="caret" onClick={toggleTree}>Avg #Periodic: {stats.avgNumPeriodic}</span>
+                                    <li><span className="caret" onClick={toggleTree}>Average #Periodic</span>
                                         <ul className="nested">
-                                            <label>Most Periodic: {stats.mostPeriodic}</label>
+                                            <label>Most Periodic</label>
                                             <br />
-                                            <label>Largest Cycle: {stats.largestPeriodicCycle}</label>
+                                            <label>Largest Cycle</label>
                                             <br />
                                         </ul>
                                     </li>
@@ -783,11 +790,11 @@ function ExploreSystems() {
 
                             <div className='statcontainer'>
                                 <ul id="myUL">
-                                    <li><span className="caret" onClick={toggleTree}>Avg #Preperiodic: {stats.avgNumPrePeriodic}</span>
+                                    <li><span className="caret" onClick={toggleTree}>Average #Preperiodic</span>
                                         <ul className="nested">
-                                            <label>Most Preperiodic: {stats.mostPreperiodic} </label>
+                                            <label>Most Preperiodic </label>
                                             <br />
-                                            <label>Largest Comp.: {stats.largestComp}</label>
+                                            <label>Largest Comp.</label>
                                             <br />
                                         </ul>
                                     </li>

--- a/Frontend/src/pages/ExploreSystems.js
+++ b/Frontend/src/pages/ExploreSystems.js
@@ -190,7 +190,21 @@ function ExploreSystems() {
             setSystems(result.data['results']);
             setFiltersApplied({...filters})
             setStat((previousState => {
-                return { ...previousState, numMaps: result.data['statistics'][0], avgAUT: Math.round(result.data['statistics'][1] * 100) / 100, numPCF: result.data['statistics'][2], avgHeight: Math.round(result.data['statistics'][3] * 100) / 100, avgResultant: Math.round(result.data['statistics'][4] * 100) / 100 }
+			return { ...previousState, 
+					numMaps: result.data['statistics'][0], 
+					avgAUT: Math.round(result.data['statistics'][1] * 100) / 100, 
+					numPCF: result.data['statistics'][2], 
+					avgHeight: Math.round(result.data['statistics'][3] * 100) / 100, 
+					avgResultant: Math.round(result.data['statistics'][4] * 100) / 100, 
+					avgPCSet: Math.round(result.data['statistics'][5] * 100) / 100, 
+					largestPCSet: result.data['statistics'][6],
+					avgNumPeriodic: Math.round(result.data['statistics'][7] * 100) / 100,
+					mostPeriodic: result.data['statistics'][8],
+					largestPeriodicCycle: result.data['statistics'][9],
+					avgNumPrePeriodic: Math.round(result.data['statistics'][10] * 100) / 100,
+					mostPreperiodic: result.data['statistics'][11],
+					largestComp: result.data['statistics'][12]
+				}
             }))
         } catch (error) {
             setSystems(null);
@@ -766,8 +780,10 @@ function ExploreSystems() {
 
                                         <ul className="nested">
                                             <label>Average Size of PC Set</label>
+                                            {stats.avgPCSet}
                                             <br />
                                             <label>Largest PC Set</label>
+                                            {stats.largestPCSet}
                                             <br />
                                         </ul>
                                     </li>
@@ -777,11 +793,11 @@ function ExploreSystems() {
 
                             <div className="statcontainer">
                                 <ul id="myUL">
-                                    <li><span className="caret" onClick={toggleTree}>Average #Periodic</span>
+                                    <li><span className="caret" onClick={toggleTree}>Average #Periodic: {stats.avgNumPeriodic}</span>
                                         <ul className="nested">
-                                            <label>Most Periodic</label>
+                                            <label>Most Periodic: {stats.mostPeriodic}</label>
                                             <br />
-                                            <label>Largest Cycle</label>
+                                            <label>Largest Cycle: {stats.largestPeriodicCycle}</label>
                                             <br />
                                         </ul>
                                     </li>
@@ -790,11 +806,11 @@ function ExploreSystems() {
 
                             <div className='statcontainer'>
                                 <ul id="myUL">
-                                    <li><span className="caret" onClick={toggleTree}>Average #Preperiodic</span>
+                                    <li><span className="caret" onClick={toggleTree}>Average #Preperiodic: {stats.avgNumPrePeriodic}</span>
                                         <ul className="nested">
-                                            <label>Most Preperiodic </label>
+                                            <label>Most Preperiodic: {stats.mostPreperiodic} </label>
                                             <br />
-                                            <label>Largest Comp.</label>
+                                            <label>Largest Comp.: {stats.largestComp}</label>
                                             <br />
                                         </ul>
                                     </li>


### PR DESCRIPTION
Fixes #165 

**What was changed?**

The periodic cardinality filter was edited so that the results were filtered on the correct results. In addition, 2 additional filters were added (number of critical points and post critical cardinality).

**Why was it changed?**

Originally, the periodic cardinality filter did not filter the intended results. This would result in incorrect values from being reported. This bug might've caused frustration, but it also presented a new possibility for filtering that could provide useful. Sorting via the number of critical points could have a use case so the Postcritically Finite section (now named Critical Points), was edited so that it could accommodate filtering via number of Critical Points. In addition, it also would provide increased functionality if the user could sort via post critical cardinality in addition to critical point cardinality. Thus in the same Critical Point filter dropdown, the filter was given a spot on the frontend and implemented on the backend. 

**How was it changed?**

For the frontend, the `ExploreSystems.js` file was edited. For clarity, the `Cardinality` filter in the `Rational Periodic Point` dropdown had it's identity changed so it better reflected what it was filtering. The `Postcritically Finite` section was renamed `Critical Points` and 2 filters were added: `Num. of Critical Points` and `Post Critical Cardinality`.

On the backend, the `postgres_connector.py` file was edited, specifically the `build_where_text()` function. The old logic for the periodic cardinality was moved down, and queries for `cp_cardinality` and `positive_in_degree` were added, pulling from the frontend and ensuring that the database responds correctly based on each of those columns.
