### PR TITLE
167 largest cycle in statistics not being computed correctly

### DIFF
--- a/Backend/postgres_connector.py
+++ b/Backend/postgres_connector.py
@@ -324,7 +324,25 @@ class PostgresConnector:
                     set(periodic_cardinalities),
                     key=periodic_cardinalities.count
                 )
-                largest_cycle = max(periodic_cardinalities)
+                sql = (
+                    'SELECT periodic_cycles'
+                    ' FROM graphs_dim_1_nf'
+                    ' JOIN rational_preperiodic_dim_1_nf'
+                    ' ON graphs_dim_1_nf.graph_id = '
+                    'rational_preperiodic_dim_1_nf.graph_id'
+                    ' JOIN functions_dim_1_nf'
+                    ' ON functions_dim_1_nf.function_id = '
+                    'rational_preperiodic_dim_1_nf.function_id'
+                    + where_text
+                )
+                cur.execute(sql)
+                periodic_cycles = [row[0] for row in cur.fetchall()]
+                longest_cycles =  [max(comp) for comp in periodic_cycles]
+                largest_cycle = max(
+                    set(longest_cycles),
+                    key=longest_cycles.count
+                )
+                print (largest_cycle)
                 sql = (
                     'SELECT preperiodic_components'
                     ' FROM graphs_dim_1_nf'

--- a/Backend/postgres_connector.py
+++ b/Backend/postgres_connector.py
@@ -334,7 +334,7 @@ class PostgresConnector:
                 )
                 cur.execute(sql)
                 periodic_cycles = [row[0] for row in cur.fetchall()]
-                longest_cycles = [max(cycle) for cycle in periodic_cycles if cycle]
+                longest_cycles = [max(val) for val in periodic_cycles if val]
                 if len(longest_cycles) > 0:
                     largest_cycle = max(longest_cycles)
                 else:
@@ -354,12 +354,14 @@ class PostgresConnector:
                 )
                 cur.execute(sql)
                 preperiodic_components = [row[0] for row in cur.fetchall()]
-                preperiodic_cardinalities = [sum(comp) for comp in preperiodic_components]
+                cardinalities = [sum(comp) for comp in preperiodic_components]
                 avg_num_preperiodic = sum(
-                    preperiodic_cardinalities
+                    cardinalities
                     ) / len(preperiodic_components)
-                most_preperiodic = max(preperiodic_cardinalities)
-                component_sizes = [max(comp) for comp in preperiodic_components if comp]
+                most_preperiodic = max(cardinalities)
+                component_sizes = [
+                    max(comp) for comp in preperiodic_components if comp
+                ]
                 if len(component_sizes) > 0:
                     largest_comp = max(component_sizes)
                 else:

--- a/Backend/postgres_connector.py
+++ b/Backend/postgres_connector.py
@@ -337,11 +337,16 @@ class PostgresConnector:
                 )
                 cur.execute(sql)
                 periodic_cycles = [row[0] for row in cur.fetchall()]
-                longest_cycles =  [max(comp) for comp in periodic_cycles]
-                largest_cycle = max(
-                    set(longest_cycles),
-                    key=longest_cycles.count
-                )
+                periodic_clean = [cycle for cycle in periodic_cycles if cycle]
+                if (len(periodic_clean) > 0):
+                    longest_cycles = [max(comp) for comp in periodic_clean]
+                    largest_cycle = max(
+                        set(longest_cycles),
+                        key=longest_cycles.count
+                    )
+                else:
+                    largest_cycle = 0
+                    
                 print (largest_cycle)
                 sql = (
                     'SELECT preperiodic_components'

--- a/Backend/postgres_connector.py
+++ b/Backend/postgres_connector.py
@@ -320,10 +320,7 @@ class PostgresConnector:
                 periodic_cardinalities = [row[0] for row in cur.fetchall()]
                 avg_num_periodic = sum(periodic_cardinalities) / len(
                     periodic_cardinalities)
-                most_periodic = max(
-                    set(periodic_cardinalities),
-                    key=periodic_cardinalities.count
-                )
+                most_periodic = max(periodic_cardinalities)
                 sql = (
                     'SELECT periodic_cycles'
                     ' FROM graphs_dim_1_nf'
@@ -337,16 +334,12 @@ class PostgresConnector:
                 )
                 cur.execute(sql)
                 periodic_cycles = [row[0] for row in cur.fetchall()]
-                periodic_clean = [cycle for cycle in periodic_cycles if cycle]
-                if (len(periodic_clean) > 0):
-                    longest_cycles = [max(comp) for comp in periodic_clean]
-                    largest_cycle = max(
-                        set(longest_cycles),
-                        key=longest_cycles.count
-                    )
+                longest_cycles = [max(cycle) for cycle in periodic_cycles if cycle]
+                if len(longest_cycles) > 0:
+                    largest_cycle = max(longest_cycles)
                 else:
                     largest_cycle = 0
-                    
+
                 print (largest_cycle)
                 sql = (
                     'SELECT preperiodic_components'
@@ -361,15 +354,16 @@ class PostgresConnector:
                 )
                 cur.execute(sql)
                 preperiodic_components = [row[0] for row in cur.fetchall()]
+                preperiodic_cardinalities = [sum(comp) for comp in preperiodic_components]
                 avg_num_preperiodic = sum(
-                    len(comp) for comp in preperiodic_components
-                ) / len(preperiodic_components)
-                component_sizes = [len(comp) for comp in preperiodic_components]
-                most_preperiodic = max(
-                    set(component_sizes),
-                    key=component_sizes.count
-                )
-                largest_comp = max(component_sizes)
+                    preperiodic_cardinalities
+                    ) / len(preperiodic_components)
+                most_preperiodic = max(preperiodic_cardinalities)
+                component_sizes = [max(comp) for comp in preperiodic_components if comp]
+                if len(component_sizes) > 0:
+                    largest_comp = max(component_sizes)
+                else:
+                    largest_comp = 0
 
 
         except Exception:


### PR DESCRIPTION
Fixes #167 

**What was changed?**

The data in the right sidebar was updated and fixed so that the statistics are correct.

**Why was it changed?**

Currently, some of the stats on the right side of the page are incorrect, as they either reference the wrong data or are parsed incorrectly. This may give users the wrong impression about the functions they are looking at and they may draw incorrect assumptions. The fix changes this so now the stats are correct for the returned functions, allowing for quick analysis.

**How was it changed?**

The `postgres_connector.py` file was changed. Specifically, the `get_statistics()` function was updated and altered so that the values that get pushed to the front end is the data that should be getting sent. There was no need to change any functionality on the frontend as all of the fields were present.
