### PR TITLE
added link to family page from function details 

### DIFF
--- a/Frontend/src/components/FunctionDetail/InfoTable.js
+++ b/Frontend/src/components/FunctionDetail/InfoTable.js
@@ -6,8 +6,15 @@ import TableContainer from '@mui/material/TableContainer';
 import TableHead from '@mui/material/TableHead';
 import TableRow from '@mui/material/TableRow';
 import Paper from '@mui/material/Paper';
+import { useNavigate } from 'react-router-dom';
 
 export default function InfoTable({ data }) {
+  const navigate = useNavigate();
+
+  const handleLinkClick = (selection) => {
+    navigate(`/family-details/${selection}`);
+  };
+
   return (
     <TableContainer className='table-component' component={Paper}>
       <Table aria-label="simple table">
@@ -18,6 +25,7 @@ export default function InfoTable({ data }) {
             <TableCell align="right"><b>Standard Model</b></TableCell>
             <TableCell align="right"><b>Degree</b></TableCell>
             <TableCell align="right"><b>Field of Definition</b></TableCell>
+            <TableCell align="right"><b>Family</b></TableCell>
           </TableRow>
         </TableHead>
         <TableBody>
@@ -27,6 +35,21 @@ export default function InfoTable({ data }) {
             <TableCell align="right">{data.display_model}</TableCell>
             <TableCell align="right">{data.degree}</TableCell>
             <TableCell align="right">{data.base_field_label}</TableCell>
+            <TableCell align="right">
+              {data.family && (
+                <button
+                  onClick={() => handleLinkClick(data.family)}
+                  style={{
+                    border: "None",
+                    color: "red",
+                    backgroundColor: "rgba(0, 0, 0, 0)",
+                    cursor: "pointer"
+                  }}
+                >
+                  {data.family}
+                </button>
+              )}
+            </TableCell>
           </TableRow>
         </TableBody>
       </Table>


### PR DESCRIPTION
Fixes #172

## What was changed
Added a new "Families" column to the function details table that displays all families associated with the function. Each family is presented as a clickable element that navigates to its corresponding family details page.

## Why was it changed
Previously, users had no way to see or navigate to the families associated with a function directly from the function details page. This addition improves navigation and provides important context about how functions relate to their families, enhancing the user's ability to explore related mathematical concepts.

## How was it changed
- Extended the InfoTable component to include a new "Family" column
- Integrated React Router's useNavigate hook for handling navigation to family detail pages
- Implemented consistent styling with existing clickable elements in the application (red text, no border, transparent background)
- Used conditional rendering to handle cases where a function might not have associated families
- Maintained the existing table structure and styling to ensure visual consistency with the rest of the application

The implementation follows the same navigation pattern used in the Families.js component to maintain consistency in user experience across the application. The family link is styled as a button to match existing UI patterns and uses the same routing structure (`/family-details/${familyId}`) as seen elsewhere in the application.