### PR TITLE
178 fix and correct statistics for ag cardinality average resultant and pc set calculations

### DIFF
--- a/Backend/postgres_connector.py
+++ b/Backend/postgres_connector.py
@@ -124,6 +124,7 @@ class PostgresConnector:
                     FROM functions_dim_1_nf
                     JOIN rational_preperiodic_dim_1_nf
                     ON functions_dim_1_nf.function_id = rational_preperiodic_dim_1_nf.function_id
+                    AND functions_dim_1_nf.base_field_label = rational_preperiodic_dim_1_nf.base_field_label
                     JOIN graphs_dim_1_nf
                     ON graphs_dim_1_nf.graph_id = rational_preperiodic_dim_1_nf.graph_id
                     {where_text}    
@@ -428,7 +429,7 @@ class PostgresConnector:
                     )
 
             elif fil in ['base_field_label']:
-                conditions.append(fil + " LIKE \'%" + values + "%\'")
+                conditions.append(f'functions_dim_1_nf.{fil} LIKE \'%{values}%\'')
 
             elif fil in ['family']:
                 print(values)

--- a/Backend/postgres_connector.py
+++ b/Backend/postgres_connector.py
@@ -429,7 +429,8 @@ class PostgresConnector:
                     )
 
             elif fil in ['base_field_label']:
-                conditions.append(f'functions_dim_1_nf.{fil} LIKE \'%{values}%\'')
+                conditions.append(
+                    f'functions_dim_1_nf.{fil} LIKE \'%{values}%\'')
 
             elif fil in ['family']:
                 print(values)


### PR DESCRIPTION
Fixes #178

**What was changed?**

Some of the stats sections including the resultant and the PC set calculations. In addition there were some minor tweaks and bug fixes.

**Why was it changed?**

Currently, the average resultant is not being computed correctly and the PC set is not being calculated correctly. This change enables the PC set and the average resultant to be used as intended for analysis of the queried functions. In addition there were multiple copies of the same function being displayed. By removing the duplicates, the results are more streamlined and less cluttered.

**How was it changed?**

All of these changes were able to be implemented in the `postgres_connector.py` file. The bug discovered with the automorphism cardinality filter was fixed by updating the query in the `get_filtered_systems()` function. Also the base field label also needed modification after the change. The stats calculations were able to be fixed in the `get_statistics()` function by adding a query and modifying the existing query for the PC set. 
