### PR TITLE
(Hopefully) Fixed Issue 184 - Enhanced critical point portrait table

### DIFF
--- a/Frontend/src/components/FunctionDetail/CriticalPointPortraitTable.js
+++ b/Frontend/src/components/FunctionDetail/CriticalPointPortraitTable.js
@@ -7,7 +7,7 @@ import TableRow from '@mui/material/TableRow';
 import Paper from '@mui/material/Paper';
 
 export default function CriticalPointPortraitTable({ data }) {
-  
+  console.log(JSON.stringify(data));
   const formatData = (key) => {
     const value = data[key];
   
@@ -25,9 +25,8 @@ export default function CriticalPointPortraitTable({ data }) {
       }
       return '[]'; // Return '[]' for empty arrays
     }
-      return 'N/A';
   };
-
+  if (data.is_pcf == true) {
   return (
     <TableContainer className='table-component' component={Paper}>
       <h3>Critical Point Portrait</h3>
@@ -35,30 +34,31 @@ export default function CriticalPointPortraitTable({ data }) {
         <TableBody>
           <TableRow>
             <TableCell component="th" scope="row"><b>Cardinality</b></TableCell>
-            <TableCell align="right">{formatData(data.critical_portrait_cardinality)}</TableCell>
+            <TableCell align="right">{data.cardinality || "N/A"}</TableCell>
           </TableRow>
           <TableRow>
-            <TableCell component="th" scope="row"><b>As Directed Graph (graph ID for now)</b></TableCell>
-            <TableCell align="right">{formatData(data.critical_portrait_graph_id)}</TableCell>
+            <TableCell component="th" scope="row"><b>Size of Post Critical Set</b></TableCell>
+            <TableCell align="right">{data.positive_in_degree || "N/A"}</TableCell>
+          </TableRow>
+          <TableRow>
+            <TableCell component="th" scope="row"><b>As Directed Graph</b></TableCell>
+            <TableCell align="right">{"test"}</TableCell>
           </TableRow>
           <TableRow>
             <TableCell component="th" scope="row"><b>Adjacency Matrix</b></TableCell>
-            <TableCell align="right">{"link"}</TableCell>
+            <TableCell align="right">{"test"}</TableCell>
           </TableRow>
           <TableRow>
-            <TableCell component="th" scope="row"><b>Components</b></TableCell>
-            <TableCell align="right">{formatData(data.critical_portrait_components)}</TableCell>
+            <TableCell component="th" scope="row"><b>Cycle Lengths</b></TableCell>
+            <TableCell align="right">{data.periodic_cycles || "N/A"}</TableCell>
           </TableRow>
           <TableRow>
-            <TableCell component="th" scope="row"><b>Structure</b></TableCell>
-            <TableCell align="right">{formatData(data.critical_portrait_structure)}</TableCell>
-          </TableRow>
-          <TableRow>
-            <TableCell component="th" scope="row"><b>Positive in Degree</b></TableCell>
-            <TableCell align="right">{formatData(data.positive_in_degree)}</TableCell>
+            <TableCell component="th" scope="row"><b>Component Sizes</b></TableCell>
+            <TableCell align="right">{data.preperiodic_components || "N/A"}</TableCell>
           </TableRow>
         </TableBody>
       </Table>
     </TableContainer>
   );
+}
 }

--- a/Frontend/src/components/FunctionDetail/CriticalPointPortraitTable.js
+++ b/Frontend/src/components/FunctionDetail/CriticalPointPortraitTable.js
@@ -25,10 +25,12 @@ export default function CriticalPointPortraitTable({ data }) {
         }
       }
       return '[]'; // Return '[]' for empty arrays
+    } else {
+      return value;
     }
   };
   
-  if (data.is_pcf == true) {
+  if (data.is_pcf) {
     return (
       <TableContainer className='table-component' component={Paper}>
         <h3>Critical Point Portrait</h3>
@@ -36,11 +38,11 @@ export default function CriticalPointPortraitTable({ data }) {
           <TableBody>
             <TableRow>
               <TableCell component="th" scope="row"><b>Cardinality</b></TableCell>
-              <TableCell align="right">{data.cardinality || "N/A"}</TableCell>
+              <TableCell align="right">{formatData("cardinality")}</TableCell>
             </TableRow>
             <TableRow>
               <TableCell component="th" scope="row"><b>Size of Post Critical Set</b></TableCell>
-              <TableCell align="right">{data.positive_in_degree || "N/A"}</TableCell>
+              <TableCell align="right">{formatData("positive_in_degree")}</TableCell>
             </TableRow>
             <TableRow>
               <TableCell component="th" scope="row"><b>As Directed Graph</b></TableCell>
@@ -59,11 +61,11 @@ export default function CriticalPointPortraitTable({ data }) {
             </TableRow>
             <TableRow>
               <TableCell component="th" scope="row"><b>Cycle Lengths</b></TableCell>
-              <TableCell align="right">{data.periodic_cycles || "N/A"}</TableCell>
+              <TableCell align="right">{formatData("periodic_cycles")}</TableCell>
             </TableRow>
             <TableRow>
               <TableCell component="th" scope="row"><b>Component Sizes</b></TableCell>
-              <TableCell align="right">{data.preperiodic_components || "N/A"}</TableCell>
+              <TableCell align="right">{formatData("preperiodic_components")}</TableCell>
             </TableRow>
           </TableBody>
         </Table>

--- a/Frontend/src/components/FunctionDetail/CriticalPointPortraitTable.js
+++ b/Frontend/src/components/FunctionDetail/CriticalPointPortraitTable.js
@@ -5,9 +5,10 @@ import TableCell from '@mui/material/TableCell';
 import TableContainer from '@mui/material/TableContainer';
 import TableRow from '@mui/material/TableRow';
 import Paper from '@mui/material/Paper';
+import AdjacencyMatrix from '../FunctionDetail/AdjacencyMatrix'
+import Copy from '../FunctionDetail/Copy'
 
 export default function CriticalPointPortraitTable({ data }) {
-  console.log(JSON.stringify(data));
   const formatData = (key) => {
     const value = data[key];
   
@@ -26,39 +27,47 @@ export default function CriticalPointPortraitTable({ data }) {
       return '[]'; // Return '[]' for empty arrays
     }
   };
+  
   if (data.is_pcf == true) {
-  return (
-    <TableContainer className='table-component' component={Paper}>
-      <h3>Critical Point Portrait</h3>
-      <Table aria-label="simple table">
-        <TableBody>
-          <TableRow>
-            <TableCell component="th" scope="row"><b>Cardinality</b></TableCell>
-            <TableCell align="right">{data.cardinality || "N/A"}</TableCell>
-          </TableRow>
-          <TableRow>
-            <TableCell component="th" scope="row"><b>Size of Post Critical Set</b></TableCell>
-            <TableCell align="right">{data.positive_in_degree || "N/A"}</TableCell>
-          </TableRow>
-          <TableRow>
-            <TableCell component="th" scope="row"><b>As Directed Graph</b></TableCell>
-            <TableCell align="right">{"test"}</TableCell>
-          </TableRow>
-          <TableRow>
-            <TableCell component="th" scope="row"><b>Adjacency Matrix</b></TableCell>
-            <TableCell align="right">{"test"}</TableCell>
-          </TableRow>
-          <TableRow>
-            <TableCell component="th" scope="row"><b>Cycle Lengths</b></TableCell>
-            <TableCell align="right">{data.periodic_cycles || "N/A"}</TableCell>
-          </TableRow>
-          <TableRow>
-            <TableCell component="th" scope="row"><b>Component Sizes</b></TableCell>
-            <TableCell align="right">{data.preperiodic_components || "N/A"}</TableCell>
-          </TableRow>
-        </TableBody>
-      </Table>
-    </TableContainer>
-  );
-}
+    return (
+      <TableContainer className='table-component' component={Paper}>
+        <h3>Critical Point Portrait</h3>
+        <Table aria-label="simple table">
+          <TableBody>
+            <TableRow>
+              <TableCell component="th" scope="row"><b>Cardinality</b></TableCell>
+              <TableCell align="right">{data.cardinality || "N/A"}</TableCell>
+            </TableRow>
+            <TableRow>
+              <TableCell component="th" scope="row"><b>Size of Post Critical Set</b></TableCell>
+              <TableCell align="right">{data.positive_in_degree || "N/A"}</TableCell>
+            </TableRow>
+            <TableRow>
+              <TableCell component="th" scope="row"><b>As Directed Graph</b></TableCell>
+              <TableCell align="right">
+                  <Copy edges={formatData("edges")} type={2} />
+              </TableCell>
+            </TableRow>
+            <TableRow>
+              <TableCell component="th" scope="row"><b>Adjacency Matrix</b></TableCell>
+              <TableCell align="right">
+                  <Copy edges={formatData("edges")} type={1} />
+                  <br>
+                  </br>
+                  <AdjacencyMatrix modalTitle={"Adjacency Matrix"} edges={formatData("edges")} />
+                </TableCell>
+            </TableRow>
+            <TableRow>
+              <TableCell component="th" scope="row"><b>Cycle Lengths</b></TableCell>
+              <TableCell align="right">{data.periodic_cycles || "N/A"}</TableCell>
+            </TableRow>
+            <TableRow>
+              <TableCell component="th" scope="row"><b>Component Sizes</b></TableCell>
+              <TableCell align="right">{data.preperiodic_components || "N/A"}</TableCell>
+            </TableRow>
+          </TableBody>
+        </Table>
+      </TableContainer>
+    );
+ }
 }


### PR DESCRIPTION
Fixes #184 

**What was changed?**

The table was updated to display the cardinality, size of post critical set, cycle lengths, and component sizes in the correct format. Additionally, the table provides links to show the directed graph and adjacency matrices for the given edges. The structure field was removed from the table. The table will not show up if it is non-PCF. 

**Why was it changed?**

This directly solves issue #184, to enhance the critical point portrait table with additional data.

**How was it changed?**

1. The `CriticalPointPotraitTable.js` file was updated. The `TableRows` within the `TableComponent` were updated to correctly show the data from the data variable using the `formatData` function. The `formatData` function was slightly modified so it now returns `N/A` if there is no data, shows a comma-separated list if the data is an array, or the value itself if it is just a single data value.
2. The adjacency matrix/directed graph table row has links to the `Copy` module to generate the adjacency matrix and directed graph from the edges data.
3. There is an if-conditional that only returns the table if PCF is true.

This is my first time with React/Flask, so hopefully I didn't mess up! Please let me know if I did anything wrong. Thank you and thanks for reading.

**Screenshots that show the changes (if applicable):**
![git working table new issue 1](https://github.com/user-attachments/assets/cc5c02cc-03c7-4f71-a4c8-638efed881e1)

