### PR TITLE
Fixed Main Function Details Page: Correct Data and Fields

### DIFF
--- a/Backend/package-lock.json
+++ b/Backend/package-lock.json
@@ -1,0 +1,109 @@
+{
+  "name": "Backend",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "dependencies": {
+        "react-router-dom": "^7.1.3"
+      }
+    },
+    "node_modules/@types/cookie": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
+      "integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==",
+      "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
+      "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/react": {
+      "version": "19.0.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.0.0.tgz",
+      "integrity": "sha512-V8AVnmPIICiWpGfm6GLzCR/W5FXLchHop40W4nXBmdlEceh16rCN8O8LNWm5bh5XUX91fh7KpA+W0TgMKmgTpQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "19.0.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.0.0.tgz",
+      "integrity": "sha512-4GV5sHFG0e/0AD4X+ySy6UJd3jVl1iNsNHdpad0qhABJ11twS3TTBnseqsKurKcsNqCEFeGL3uLpVChpIO3QfQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "scheduler": "^0.25.0"
+      },
+      "peerDependencies": {
+        "react": "^19.0.0"
+      }
+    },
+    "node_modules/react-router": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.1.3.tgz",
+      "integrity": "sha512-EezYymLY6Guk/zLQ2vRA8WvdUhWFEj5fcE3RfWihhxXBW7+cd1LsIiA3lmx+KCmneAGQuyBv820o44L2+TtkSA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/cookie": "^0.6.0",
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0",
+        "turbo-stream": "2.4.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.1.3.tgz",
+      "integrity": "sha512-qQGTE+77hleBzv9SIUIkGRvuFBQGagW+TQKy53UTZAO/3+YFNBYvRsNIZ1GT17yHbc63FylMOdS+m3oUriF1GA==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.1.3"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.25.0.tgz",
+      "integrity": "sha512-xFVuu11jh+xcO7JOAGJNOXld8/TcEHK/4CituBUeUb5hqxJLj9YuemAEuvm9gQ/+pgXYfbQuqAkiYu+u7YEsNA==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
+      "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==",
+      "license": "MIT"
+    },
+    "node_modules/turbo-stream": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/turbo-stream/-/turbo-stream-2.4.0.tgz",
+      "integrity": "sha512-FHncC10WpBd2eOmGwpmQsWLDoK4cqsA/UT/GqNoaKOQnT8uzhtCbg3EoUDMvqpOSAI0S26mr0rkjzbOO6S3v1g==",
+      "license": "ISC"
+    }
+  }
+}

--- a/Backend/package.json
+++ b/Backend/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "react-router-dom": "^7.1.3"
+  }
+}

--- a/Backend/postgres_connector.py
+++ b/Backend/postgres_connector.py
@@ -90,7 +90,6 @@ class PostgresConnector:
                     result = {'modelLabel': model_label, **temp}
                 else:
                     result = {}
-            
         except Exception:
             self.connection.rollback()
             result = {}
@@ -127,7 +126,7 @@ class PostgresConnector:
                     AND functions_dim_1_nf.base_field_label = rational_preperiodic_dim_1_nf.base_field_label
                     JOIN graphs_dim_1_nf
                     ON graphs_dim_1_nf.graph_id = rational_preperiodic_dim_1_nf.graph_id
-                    {where_text}    
+                    {where_text}
                     """
                 )
                 with self.connection.cursor(

--- a/Backend/postgres_connector.py
+++ b/Backend/postgres_connector.py
@@ -90,7 +90,7 @@ class PostgresConnector:
                     result = {'modelLabel': model_label, **temp}
                 else:
                     result = {}
-
+            print("Fetched system data:", result)  # Debugging print
         except Exception:
             self.connection.rollback()
             result = {}

--- a/Backend/postgres_connector.py
+++ b/Backend/postgres_connector.py
@@ -90,7 +90,7 @@ class PostgresConnector:
                     result = {'modelLabel': model_label, **temp}
                 else:
                     result = {}
-            print("Fetched system data:", result)  # Debugging print
+            
         except Exception:
             self.connection.rollback()
             result = {}

--- a/Frontend/src/components/FunctionDetail/AutomorphismGroupTable.js
+++ b/Frontend/src/components/FunctionDetail/AutomorphismGroupTable.js
@@ -14,7 +14,11 @@ export default function AutomorphismGroupTable({ data }) {
         <TableBody>
           <TableRow>
             <TableCell component="th" scope="row"><b>Cardinality</b></TableCell>
-            <TableCell align="right">{data.automorphism_group_cardinality}</TableCell>
+            <TableCell align="right">
+              {data.automorphism_group_cardinality !== undefined 
+              ? data.automorphism_group_cardinality 
+              : "N/A"}
+            </TableCell>
           </TableRow>
           <TableRow>
             <TableCell component="th" scope="row"><b>Structure</b></TableCell>

--- a/Frontend/src/components/FunctionDetail/InfoTable.js
+++ b/Frontend/src/components/FunctionDetail/InfoTable.js
@@ -89,16 +89,11 @@ export default function InfoTable({ data }) {
           <TableRow>
             <TableCell component="th" scope="row">{data.modelLabel}</TableCell>
             <TableCell align="right">{data.base_field_label}</TableCell>
-            <TableCell align="right">
-              {data.is_polynomial && data.models?.[data.display_model]?.polys_val
-                ? renderExponent(processInput(data.models[data.display_model].polys_val[0]))
-                : data.reduced_model || "N/A"}   
-       
-            </TableCell>
+            <TableCell align="right">{data.display_model}</TableCell>
             <TableCell align="right">{data.degree}</TableCell>
             <TableCell align="right">
             <a
-                href={`https://www.lmfdb.org/NumberFields/${data.base_field_label}`}
+                href={`https://www.lmfdb.org/NumberField/${data.base_field_label}`}
                 style={{ color: "red", textDecoration: "none" }}
                 target="_blank"
                 rel="noopener noreferrer"

--- a/Frontend/src/components/FunctionDetail/InfoTable.js
+++ b/Frontend/src/components/FunctionDetail/InfoTable.js
@@ -8,13 +8,70 @@ import TableRow from '@mui/material/TableRow';
 import Paper from '@mui/material/Paper';
 import { useNavigate } from 'react-router-dom';
 
+const Superscript = ({ children }) => {
+  return (
+    <sup style={{ fontSize: '0.6em', verticalAlign: 'super' }}>
+      {children}
+    </sup>
+  );
+};
+
+const renderExponent = (expressionArray) => {
+  return expressionArray.map((expression, index) => {
+    const parts = expression.split(/(\^[\d]+)/);
+    const formattedExpression = parts.map((part, i) =>
+      part.startsWith('^') ? <Superscript key={i}>{part.slice(1)}</Superscript> : part
+    );
+
+    return (
+      <React.Fragment key={index}>
+        {formattedExpression}
+        {index !== expressionArray.length - 1 && <span> : </span>}
+      </React.Fragment>
+    );
+  });
+};
+
+function processInput(input) {
+  if (!input) return [];
+
+  const polynomials = input.slice(2, -2).split('},{');
+  return polynomials.map((poly) => {
+    const coeffs = poly.split(',');
+    let expression = '';
+
+    coeffs.forEach((coefficient, i) => {
+      if (coefficient !== '0') {
+        let monomial = '';
+        const d = coeffs.length - 1;
+        
+        if (i === 0) monomial = `x^${d}`;
+        else if (i === d) monomial = `y^${d}`;
+        else if (i === 1 && d === 1) monomial = 'xy';
+        else if (i === 1) monomial = `x^${d - i}y`;
+        else if (d - i === 1) monomial = `x y^${i}`;
+        else monomial = `x^${d - i} y^${i}`;
+
+        expression += coefficient === '1' ? monomial :
+                      coefficient === '-1' ? `-${monomial}` :
+                      `${coefficient}${monomial}`;
+
+        if (i !== d) expression += '+';
+      }
+    });
+
+    return expression;
+  });
+}
+
+
 export default function InfoTable({ data }) {
   const navigate = useNavigate();
 
   const handleLinkClick = (selection) => {
     navigate(`/family-details/${selection}`);
   };
-
+  console.log(data.display_model);
   return (
     <TableContainer className='table-component' component={Paper}>
       <Table aria-label="simple table">
@@ -32,9 +89,23 @@ export default function InfoTable({ data }) {
           <TableRow>
             <TableCell component="th" scope="row">{data.modelLabel}</TableCell>
             <TableCell align="right">{data.base_field_label}</TableCell>
-            <TableCell align="right">{data.display_model}</TableCell>
+            <TableCell align="right">
+              {data.is_polynomial && data.models?.[data.display_model]?.polys_val
+                ? renderExponent(processInput(data.models[data.display_model].polys_val[0]))
+                : data.reduced_model || "N/A"}   
+       
+            </TableCell>
             <TableCell align="right">{data.degree}</TableCell>
-            <TableCell align="right">{data.base_field_label}</TableCell>
+            <TableCell align="right">
+            <a
+                href={`https://www.lmfdb.org/NumberFields/${data.base_field_label}`}
+                style={{ color: "red", textDecoration: "none" }}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                {data.base_field_label}
+              </a>
+            </TableCell>
             <TableCell align="right">
               {data.family && (
                 <button

--- a/Frontend/src/components/FunctionDetail/InfoTable.js
+++ b/Frontend/src/components/FunctionDetail/InfoTable.js
@@ -7,6 +7,7 @@ import TableHead from '@mui/material/TableHead';
 import TableRow from '@mui/material/TableRow';
 import Paper from '@mui/material/Paper';
 import { useNavigate } from 'react-router-dom';
+import { processInput, renderExponent, splitOutermostCommas } from './ModelsTable';
 
 
 export default function InfoTable({ data }) {
@@ -15,9 +16,43 @@ export default function InfoTable({ data }) {
   const handleLinkClick = (selection) => {
     navigate(`/family-details/${selection}`);
   };
-  console.log(data.display_model);
+  
+  const standard_model = data.display_model;
+  let polynomial;
+  let modelKey;
+  if (!standard_model) {
+    modelKey= null;
+    polynomial = null;
+  }
+  else if (standard_model==="monic centered"){
+    modelKey= "monic_centered";
+    polynomial = data.monic_centered;
+  }
+
+  else if (standard_model==="chebyshev"){
+    modelKey= "original_model" // I see that polynomial of chebysev is similar in all models
+    polynomial = data.original_model;
+  }
+
+  else {
+    modelKey= `{standard_model}_model`; // I see in the display_model, there're only monic_centered, chebysev, and reduced
+    // I do this just in case in the future we have more models
+    polynomial= data[`${standard_model}_model`];
+  }
+
+  let polynomialExpression;
+  if (polynomial) {
+    const modelData= splitOutermostCommas(polynomial);
+    polynomialExpression= renderExponent(processInput(modelData[0]));
+  }
+  console.log("Standard Model Name:", standard_model);
+  console.log("Model Key Used:", modelKey);
+  console.log("Polynomial Data Found:", polynomial);
+
+
   return (
     <TableContainer className='table-component' component={Paper}>
+      <h3>Function Details</h3>
       <Table aria-label="simple table">
         <TableHead>
           <TableRow>
@@ -33,12 +68,12 @@ export default function InfoTable({ data }) {
           <TableRow>
             <TableCell component="th" scope="row">{data.modelLabel}</TableCell>
             <TableCell align="right">{data.base_field_label}</TableCell>
-            <TableCell align="right">{data.display_model}</TableCell>
+            <TableCell align="right">{polynomialExpression}</TableCell>
             <TableCell align="right">{data.degree}</TableCell>
             <TableCell align="right">
             <a
                 href={`https://www.lmfdb.org/NumberField/${data.base_field_label}`}
-                style={{ color: "red", textDecoration: "none" }}
+                style={{ color: "blue", textDecoration: "underline" }}
                 target="_blank"
                 rel="noopener noreferrer"
               >

--- a/Frontend/src/components/FunctionDetail/InfoTable.js
+++ b/Frontend/src/components/FunctionDetail/InfoTable.js
@@ -8,62 +8,6 @@ import TableRow from '@mui/material/TableRow';
 import Paper from '@mui/material/Paper';
 import { useNavigate } from 'react-router-dom';
 
-const Superscript = ({ children }) => {
-  return (
-    <sup style={{ fontSize: '0.6em', verticalAlign: 'super' }}>
-      {children}
-    </sup>
-  );
-};
-
-const renderExponent = (expressionArray) => {
-  return expressionArray.map((expression, index) => {
-    const parts = expression.split(/(\^[\d]+)/);
-    const formattedExpression = parts.map((part, i) =>
-      part.startsWith('^') ? <Superscript key={i}>{part.slice(1)}</Superscript> : part
-    );
-
-    return (
-      <React.Fragment key={index}>
-        {formattedExpression}
-        {index !== expressionArray.length - 1 && <span> : </span>}
-      </React.Fragment>
-    );
-  });
-};
-
-function processInput(input) {
-  if (!input) return [];
-
-  const polynomials = input.slice(2, -2).split('},{');
-  return polynomials.map((poly) => {
-    const coeffs = poly.split(',');
-    let expression = '';
-
-    coeffs.forEach((coefficient, i) => {
-      if (coefficient !== '0') {
-        let monomial = '';
-        const d = coeffs.length - 1;
-        
-        if (i === 0) monomial = `x^${d}`;
-        else if (i === d) monomial = `y^${d}`;
-        else if (i === 1 && d === 1) monomial = 'xy';
-        else if (i === 1) monomial = `x^${d - i}y`;
-        else if (d - i === 1) monomial = `x y^${i}`;
-        else monomial = `x^${d - i} y^${i}`;
-
-        expression += coefficient === '1' ? monomial :
-                      coefficient === '-1' ? `-${monomial}` :
-                      `${coefficient}${monomial}`;
-
-        if (i !== d) expression += '+';
-      }
-    });
-
-    return expression;
-  });
-}
-
 
 export default function InfoTable({ data }) {
   const navigate = useNavigate();

--- a/Frontend/src/components/FunctionDetail/ModelsTable.js
+++ b/Frontend/src/components/FunctionDetail/ModelsTable.js
@@ -15,99 +15,98 @@ export default function ModelsTable({ data }) {
 	modelKeys.splice(position, 1);
     }
 
-   const Superscript = ({ children }) => {
-      return (
-	<sup style={{ fontSize: '0.6em', verticalAlign: 'super' }}>
-	  {children}
-	</sup>
-      );
-    };
-
-    const renderExponent = (expressionArray) => {
-      const formattedExpressions = [];
-
-      expressionArray.forEach((expression, index) => {
-	const parts = expression.split(/(\^[\d]+)/);
-	const formattedExpression = [];
-
-	for (let i = 0; i < parts.length; i++) {
-	  if (parts[i].startsWith('^')) {
-	    const exponentValue = parts[i].slice(1);
-	    formattedExpression.push(<Superscript key={i}>{exponentValue}</Superscript>);
-	  } else {
-	    formattedExpression.push(parts[i]);
-	  }
-	}
-
-	formattedExpressions.push(
-	  <React.Fragment key={index}>
-	    {formattedExpression}
-	    {index !== expressionArray.length - 1 && <span> : </span>}
-	  </React.Fragment>
-	);
-      });
-
-      return formattedExpressions;
-    }; 
-    
-
-    function processInput(input) {
-	// Remove outer braces and split by '},{' to get individual polynomial coefficient sets
-	const polynomials = input.slice(2, -2).split('},{');
-	
-	const result = [];
-	
-	// Iterate over each polynomial
-	for (let poly of polynomials) {
-	    // Split the polynomial coefficients by ','
-	    const coeffs = poly.split(',');
-	    
-	    // Construct the polynomial expression
-	    let polynomialExpression = '';
-	    for (let i = 0; i < coeffs.length; i++) {
-		const coefficient = coeffs[i];
-		if (coefficient !== '0') {
-		    // Construct monomial expression based on index
-		    let monomial = '';
-		    if (i === 0) {
-			monomial = 'x^' + (coeffs.length - 1);
-		    } else if (i === coeffs.length - 1) {
-			monomial = 'y^' + (coeffs.length - 1);
-		    } else if (i === 1 && (coeffs.length - 1) === 1) {
-			monomial = 'xy';
-		    } else if (i === 1) {
-			monomial = 'x^' + (coeffs.length - 1 - i) + 'y';
-		    } else if ((coeffs.length - 1 - i) === 1) {
-			monomial = 'x' + 'y^' + i;
-		    } else {
-			monomial = 'x^' + (coeffs.length - 1 - i) + 'y^' + i;
-		    }
-		    
-		    // Add coefficient with monomial
-		    if (coefficient === '1') {
-			polynomialExpression += monomial;
-		    } else if (coefficient === '-1') {
-			polynomialExpression += '-' + monomial;
-		    } else {
-			polynomialExpression += coefficient + monomial;
-		    }
-		    
-		    // Add '+' if not the last term and coefficient is not zero
-		    // && coeffs[i + 1] !== '0'
-		    if (i !== coeffs.length - 1 ) {
-			polynomialExpression += '+';
-		    }
+	const Superscript = ({ children }) => {
+		return (
+		<sup style={{ fontSize: '0.6em', verticalAlign: 'super' }}>
+		{children}
+		</sup>
+		);
+		};
+		
+		const renderExponent = (expressionArray) => {
+		const formattedExpressions = [];
+		
+		expressionArray.forEach((expression, index) => {
+		const parts = expression.split(/(\^[\d]+)/);
+		const formattedExpression = [];
+		
+		for (let i = 0; i < parts.length; i++) {
+		if (parts[i].startsWith('^')) {
+			const exponentValue = parts[i].slice(1);
+			formattedExpression.push(<Superscript key={i}>{exponentValue}</Superscript>);
+		} else {
+			formattedExpression.push(parts[i]);
 		}
-	    }
-	    
-	    // Push polynomial expression to result array
-	    result.push(polynomialExpression);
-	}
-	
-	return result;
-    }
-
-  return (
+		}
+		
+		formattedExpressions.push(
+		<React.Fragment key={index}>
+			{formattedExpression}
+			{index !== expressionArray.length - 1 && <span> : </span>}
+		</React.Fragment>
+		);
+		});
+		
+		return formattedExpressions;
+		}; 
+		
+		
+		function processInput(input) {
+		// Remove outer braces and split by '},{' to get individual polynomial coefficient sets
+		const polynomials = input.slice(2, -2).split('},{');
+		
+		const result = [];
+		
+		// Iterate over each polynomial
+		for (let poly of polynomials) {
+			// Split the polynomial coefficients by ','
+			const coeffs = poly.split(',');
+			
+			// Construct the polynomial expression
+			let polynomialExpression = '';
+			for (let i = 0; i < coeffs.length; i++) {
+			const coefficient = coeffs[i];
+			if (coefficient !== '0') {
+				// Construct monomial expression based on index
+				let monomial = '';
+				if (i === 0) {
+				monomial = 'x^' + (coeffs.length - 1);
+				} else if (i === coeffs.length - 1) {
+				monomial = 'y^' + (coeffs.length - 1);
+				} else if (i === 1 && (coeffs.length - 1) === 1) {
+				monomial = 'xy';
+				} else if (i === 1) {
+				monomial = 'x^' + (coeffs.length - 1 - i) + 'y';
+				} else if ((coeffs.length - 1 - i) === 1) {
+				monomial = 'x' + 'y^' + i;
+				} else {
+				monomial = 'x^' + (coeffs.length - 1 - i) + 'y^' + i;
+				}
+				
+				// Add coefficient with monomial
+				if (coefficient === '1') {
+				polynomialExpression += monomial;
+				} else if (coefficient === '-1') {
+				polynomialExpression += '-' + monomial;
+				} else {
+				polynomialExpression += coefficient + monomial;
+				}
+				
+				// Add '+' if not the last term and coefficient is not zero
+				// && coeffs[i + 1] !== '0'
+				if (i !== coeffs.length - 1 ) {
+				polynomialExpression += '+';
+				}
+			}
+			}
+			
+			// Push polynomial expression to result array
+			result.push(polynomialExpression);
+		}
+		
+		return result;
+		}
+	return (
     <TableContainer className='table-component' component={Paper}>
       <h3>Models:</h3>
       <Table aria-label="simple table">
@@ -160,3 +159,4 @@ const splitOutermostCommas = (str) => {
   parts.push(temp.trim().replace(/["()]/g, '')); // Push the last part and remove characters
   return parts;
 };
+

--- a/Frontend/src/components/FunctionDetail/ModelsTable.js
+++ b/Frontend/src/components/FunctionDetail/ModelsTable.js
@@ -93,7 +93,7 @@ export const renderExponent = (expressionArray) => {
 	);
 	});
 
-	return formattedExpressions;
+	return(<><span>[ </span>{formattedExpressions}<span> ]</span></>);
 	}; 
 
 

--- a/Frontend/src/components/FunctionDetail/ModelsTable.js
+++ b/Frontend/src/components/FunctionDetail/ModelsTable.js
@@ -15,98 +15,99 @@ export default function ModelsTable({ data }) {
 	modelKeys.splice(position, 1);
     }
 
-	const Superscript = ({ children }) => {
-		return (
-		<sup style={{ fontSize: '0.6em', verticalAlign: 'super' }}>
-		{children}
-		</sup>
-		);
-		};
-		
-		const renderExponent = (expressionArray) => {
-		const formattedExpressions = [];
-		
-		expressionArray.forEach((expression, index) => {
-		const parts = expression.split(/(\^[\d]+)/);
-		const formattedExpression = [];
-		
-		for (let i = 0; i < parts.length; i++) {
-		if (parts[i].startsWith('^')) {
-			const exponentValue = parts[i].slice(1);
-			formattedExpression.push(<Superscript key={i}>{exponentValue}</Superscript>);
-		} else {
-			formattedExpression.push(parts[i]);
+   const Superscript = ({ children }) => {
+      return (
+	<sup style={{ fontSize: '0.6em', verticalAlign: 'super' }}>
+	  {children}
+	</sup>
+      );
+    };
+
+    const renderExponent = (expressionArray) => {
+      const formattedExpressions = [];
+
+      expressionArray.forEach((expression, index) => {
+	const parts = expression.split(/(\^[\d]+)/);
+	const formattedExpression = [];
+
+	for (let i = 0; i < parts.length; i++) {
+	  if (parts[i].startsWith('^')) {
+	    const exponentValue = parts[i].slice(1);
+	    formattedExpression.push(<Superscript key={i}>{exponentValue}</Superscript>);
+	  } else {
+	    formattedExpression.push(parts[i]);
+	  }
+	}
+
+	formattedExpressions.push(
+	  <React.Fragment key={index}>
+	    {formattedExpression}
+	    {index !== expressionArray.length - 1 && <span> : </span>}
+	  </React.Fragment>
+	);
+      });
+
+      return formattedExpressions;
+    }; 
+    
+
+    function processInput(input) {
+	// Remove outer braces and split by '},{' to get individual polynomial coefficient sets
+	const polynomials = input.slice(2, -2).split('},{');
+	
+	const result = [];
+	
+	// Iterate over each polynomial
+	for (let poly of polynomials) {
+	    // Split the polynomial coefficients by ','
+	    const coeffs = poly.split(',');
+	    
+	    // Construct the polynomial expression
+	    let polynomialExpression = '';
+	    for (let i = 0; i < coeffs.length; i++) {
+		const coefficient = coeffs[i];
+		if (coefficient !== '0') {
+		    // Construct monomial expression based on index
+		    let monomial = '';
+		    if (i === 0) {
+			monomial = 'x^' + (coeffs.length - 1);
+		    } else if (i === coeffs.length - 1) {
+			monomial = 'y^' + (coeffs.length - 1);
+		    } else if (i === 1 && (coeffs.length - 1) === 1) {
+			monomial = 'xy';
+		    } else if (i === 1) {
+			monomial = 'x^' + (coeffs.length - 1 - i) + 'y';
+		    } else if ((coeffs.length - 1 - i) === 1) {
+			monomial = 'x' + 'y^' + i;
+		    } else {
+			monomial = 'x^' + (coeffs.length - 1 - i) + 'y^' + i;
+		    }
+		    
+		    // Add coefficient with monomial
+		    if (coefficient === '1') {
+			polynomialExpression += monomial;
+		    } else if (coefficient === '-1') {
+			polynomialExpression += '-' + monomial;
+		    } else {
+			polynomialExpression += coefficient + monomial;
+		    }
+		    
+		    // Add '+' if not the last term and coefficient is not zero
+		    // && coeffs[i + 1] !== '0'
+		    if (i !== coeffs.length - 1 ) {
+			polynomialExpression += '+';
+		    }
 		}
-		}
-		
-		formattedExpressions.push(
-		<React.Fragment key={index}>
-			{formattedExpression}
-			{index !== expressionArray.length - 1 && <span> : </span>}
-		</React.Fragment>
-		);
-		});
-		
-		return formattedExpressions;
-		}; 
-		
-		
-		function processInput(input) {
-		// Remove outer braces and split by '},{' to get individual polynomial coefficient sets
-		const polynomials = input.slice(2, -2).split('},{');
-		
-		const result = [];
-		
-		// Iterate over each polynomial
-		for (let poly of polynomials) {
-			// Split the polynomial coefficients by ','
-			const coeffs = poly.split(',');
-			
-			// Construct the polynomial expression
-			let polynomialExpression = '';
-			for (let i = 0; i < coeffs.length; i++) {
-			const coefficient = coeffs[i];
-			if (coefficient !== '0') {
-				// Construct monomial expression based on index
-				let monomial = '';
-				if (i === 0) {
-				monomial = 'x^' + (coeffs.length - 1);
-				} else if (i === coeffs.length - 1) {
-				monomial = 'y^' + (coeffs.length - 1);
-				} else if (i === 1 && (coeffs.length - 1) === 1) {
-				monomial = 'xy';
-				} else if (i === 1) {
-				monomial = 'x^' + (coeffs.length - 1 - i) + 'y';
-				} else if ((coeffs.length - 1 - i) === 1) {
-				monomial = 'x' + 'y^' + i;
-				} else {
-				monomial = 'x^' + (coeffs.length - 1 - i) + 'y^' + i;
-				}
-				
-				// Add coefficient with monomial
-				if (coefficient === '1') {
-				polynomialExpression += monomial;
-				} else if (coefficient === '-1') {
-				polynomialExpression += '-' + monomial;
-				} else {
-				polynomialExpression += coefficient + monomial;
-				}
-				
-				// Add '+' if not the last term and coefficient is not zero
-				// && coeffs[i + 1] !== '0'
-				if (i !== coeffs.length - 1 ) {
-				polynomialExpression += '+';
-				}
-			}
-			}
-			
-			// Push polynomial expression to result array
-			result.push(polynomialExpression);
-		}
-		
-		return result;
-		}
-	return (
+	    }
+	    
+	    // Push polynomial expression to result array
+	    result.push(polynomialExpression);
+	}
+	
+	return result;
+    }
+
+  return (
     <TableContainer className='table-component' component={Paper}>
       <h3>Models:</h3>
       <Table aria-label="simple table">
@@ -159,4 +160,3 @@ const splitOutermostCommas = (str) => {
   parts.push(temp.trim().replace(/["()]/g, '')); // Push the last part and remove characters
   return parts;
 };
-

--- a/Frontend/src/components/FunctionDetail/ModelsTable.js
+++ b/Frontend/src/components/FunctionDetail/ModelsTable.js
@@ -7,51 +7,8 @@ import TableHead from '@mui/material/TableHead';
 import TableRow from '@mui/material/TableRow';
 import Paper from '@mui/material/Paper';
 
-export default function ModelsTable({ data }) {
-  // Extracting keys containing "_model" from the data object
-    const modelKeys = Object.keys(data).filter(key => key.includes("_model"));
-    if( modelKeys.includes("display_model")) {
-	let position = modelKeys.indexOf("display_model");
-	modelKeys.splice(position, 1);
-    }
-
-   const Superscript = ({ children }) => {
-      return (
-	<sup style={{ fontSize: '0.6em', verticalAlign: 'super' }}>
-	  {children}
-	</sup>
-      );
-    };
-
-    const renderExponent = (expressionArray) => {
-      const formattedExpressions = [];
-
-      expressionArray.forEach((expression, index) => {
-	const parts = expression.split(/(\^[\d]+)/);
-	const formattedExpression = [];
-
-	for (let i = 0; i < parts.length; i++) {
-	  if (parts[i].startsWith('^')) {
-	    const exponentValue = parts[i].slice(1);
-	    formattedExpression.push(<Superscript key={i}>{exponentValue}</Superscript>);
-	  } else {
-	    formattedExpression.push(parts[i]);
-	  }
-	}
-
-	formattedExpressions.push(
-	  <React.Fragment key={index}>
-	    {formattedExpression}
-	    {index !== expressionArray.length - 1 && <span> : </span>}
-	  </React.Fragment>
-	);
-      });
-
-      return formattedExpressions;
-    }; 
-    
-
-    function processInput(input) {
+// move processInput and renderExponent to use them in InfoTable.js
+export function processInput(input) {
 	// Remove outer braces and split by '},{' to get individual polynomial coefficient sets
 	const polynomials = input.slice(2, -2).split('},{');
 	
@@ -106,7 +63,48 @@ export default function ModelsTable({ data }) {
 	
 	return result;
     }
+export const renderExponent = (expressionArray) => {
+	const formattedExpressions = [];
+	const Superscript = ({ children }) => {
+		return (
+	  <sup style={{ fontSize: '0.6em', verticalAlign: 'super' }}>
+		{children}
+	  </sup>
+		);
+	  };
+	expressionArray.forEach((expression, index) => {
+	const parts = expression.split(/(\^[\d]+)/);
+	const formattedExpression = [];
 
+	for (let i = 0; i < parts.length; i++) {
+	if (parts[i].startsWith('^')) {
+		const exponentValue = parts[i].slice(1);
+		formattedExpression.push(<Superscript key={i}>{exponentValue}</Superscript>);
+	} else {
+		formattedExpression.push(parts[i]);
+	}
+	}
+
+	formattedExpressions.push(
+	<React.Fragment key={index}>
+		{formattedExpression}
+		{index !== expressionArray.length - 1 && <span> : </span>}
+	</React.Fragment>
+	);
+	});
+
+	return formattedExpressions;
+	}; 
+
+
+export default function ModelsTable({ data }) {
+  // Extracting keys containing "_model" from the data object
+    const modelKeys = Object.keys(data).filter(key => key.includes("_model"));
+    if( modelKeys.includes("display_model")) {
+	let position = modelKeys.indexOf("display_model");
+	modelKeys.splice(position, 1);
+    }
+    
   return (
     <TableContainer className='table-component' component={Paper}>
       <h3>Models:</h3>
@@ -143,7 +141,7 @@ export default function ModelsTable({ data }) {
 }
 
 // Function to split the string at the outermost commas
-const splitOutermostCommas = (str) => {
+export const splitOutermostCommas = (str) => {
   const parts = [];
   let temp = '';
   let openBrackets = 0;
@@ -160,3 +158,4 @@ const splitOutermostCommas = (str) => {
   parts.push(temp.trim().replace(/["()]/g, '')); // Push the last part and remove characters
   return parts;
 };
+

--- a/Frontend/src/components/FunctionDetail/ModelsTable.js
+++ b/Frontend/src/components/FunctionDetail/ModelsTable.js
@@ -7,130 +7,105 @@ import TableHead from '@mui/material/TableHead';
 import TableRow from '@mui/material/TableRow';
 import Paper from '@mui/material/Paper';
 
-// move processInput and renderExponent to use them in InfoTable.js
-export function processInput(input) {
-	// Remove outer braces and split by '},{' to get individual polynomial coefficient sets
-	const polynomials = input.slice(2, -2).split('},{');
-	
-	const result = [];
-	
-	// Iterate over each polynomial
-	for (let poly of polynomials) {
-	    // Split the polynomial coefficients by ','
-	    const coeffs = poly.split(',');
-	    
-	    // Construct the polynomial expression
-	    let polynomialExpression = '';
-	    for (let i = 0; i < coeffs.length; i++) {
-		const coefficient = coeffs[i];
-		if (coefficient !== '0') {
-		    // Construct monomial expression based on index
-		    let monomial = '';
-		    if (i === 0) {
-			monomial = 'x^' + (coeffs.length - 1);
-		    } else if (i === coeffs.length - 1) {
-			monomial = 'y^' + (coeffs.length - 1);
-		    } else if (i === 1 && (coeffs.length - 1) === 1) {
-			monomial = 'xy';
-		    } else if (i === 1) {
-			monomial = 'x^' + (coeffs.length - 1 - i) + 'y';
-		    } else if ((coeffs.length - 1 - i) === 1) {
-			monomial = 'x' + 'y^' + i;
-		    } else {
-			monomial = 'x^' + (coeffs.length - 1 - i) + 'y^' + i;
-		    }
-		    
-		    // Add coefficient with monomial
-		    if (coefficient === '1') {
-			polynomialExpression += monomial;
-		    } else if (coefficient === '-1') {
-			polynomialExpression += '-' + monomial;
-		    } else {
-			polynomialExpression += coefficient + monomial;
-		    }
-		    
-		    // Add '+' if not the last term and coefficient is not zero
-		    // && coeffs[i + 1] !== '0'
-		    if (i !== coeffs.length - 1 ) {
-			polynomialExpression += '+';
-		    }
-		}
-	    }
-	    
-	    // Push polynomial expression to result array
-	    result.push(polynomialExpression);
-	}
-	
-	return result;
-    }
 export const renderExponent = (expressionArray) => {
-	const formattedExpressions = [];
-	const Superscript = ({ children }) => {
-		return (
-	  <sup style={{ fontSize: '0.6em', verticalAlign: 'super' }}>
-		{children}
-	  </sup>
-		);
-	  };
-	expressionArray.forEach((expression, index) => {
-	const parts = expression.split(/(\^[\d]+)/);
-	const formattedExpression = [];
+	const Superscript = ({ children }) => (
+		<sup style={{ fontSize: '0.6em', verticalAlign: 'super' }}>{children}</sup>
+	  );
+    return expressionArray.map((expression, index) => {
+      const parts = expression.split(/(\^[\d]+)/);
+      return (
+        <React.Fragment key={index}>
+          {parts.map((part, i) =>
+            part.startsWith('^') ? (
+              <Superscript key={i}>{part.slice(1)}</Superscript>
+            ) : (
+              part
+            )
+          )}
+          {index !== expressionArray.length - 1 && <span> : </span>}
+        </React.Fragment>
+      );
+    });
+  };
+export function processInput(input) {
+	const polynomials = input.slice(2, -2).split('},{');
+	const formattedPolynomials = polynomials.map(poly => {
+	const coeffs = poly.split(',');
+	const formattedPoly = coeffs
+		.map((coefficient, i) => {
+		if (coefficient === '0') return '';
+		const exponentX = coeffs.length - 1 - i;
+		const exponentY = i;
+		let monomial = '';
+		if (exponentX > 0) monomial += `x^${exponentX}`;
+		if (exponentY > 0) monomial += `y^${exponentY}`;
+		return coefficient === '1' ? monomial : `${coefficient}${monomial}`;
+		})
+		.filter(Boolean)
+		.join(' + ')
+		.replace(/\+ -/g, '- ') // Ensures correct spacing for negatives
+		.replace(/\+$/, ''); // Remove trailing + symbol
 
-	for (let i = 0; i < parts.length; i++) {
-	if (parts[i].startsWith('^')) {
-		const exponentValue = parts[i].slice(1);
-		formattedExpression.push(<Superscript key={i}>{exponentValue}</Superscript>);
+	return formattedPoly;
+	});
+  
+    // Return as an array containing one string (wrapped in brackets)
+    return [`[${formattedPolynomials.join(' : ')}]`];
+  }
+
+export const splitOutermostCommas = (str) => {
+	const parts = [];
+	let temp = '';
+	let openBrackets = 0;
+	for (let i = 0; i < str.length; i++) {
+	if (str[i] === '{') openBrackets++;
+	else if (str[i] === '}') openBrackets--;
+	if (str[i] === ',' && openBrackets === 0) {
+		parts.push(temp.trim().replace(/["()]/g, ''));
+		temp = '';
 	} else {
-		formattedExpression.push(parts[i]);
+		temp += str[i];
 	}
 	}
-
-	formattedExpressions.push(
-	<React.Fragment key={index}>
-		{formattedExpression}
-		{index !== expressionArray.length - 1 && <span> : </span>}
-	</React.Fragment>
-	);
+	parts.push(temp.trim().replace(/["()]/g, ''));
+	return parts;
+};
+  
+export default function ModelsTable({ data }) {
+	const modelKeys = Object.keys(data).filter(
+		key => key.includes('_model') && key !== 'display_model'
+		);
+	// Filter out models that have no data to display
+	const relevantModels = modelKeys.filter(key => {
+	const modelData = data[key] ? splitOutermostCommas(data[key]) : [];
+	return modelData.some(value => value && value.trim() !== '');
 	});
 
-	return(<><span>[ </span>{formattedExpressions}<span> ]</span></>);
-	}; 
-
-
-export default function ModelsTable({ data }) {
-  // Extracting keys containing "_model" from the data object
-    const modelKeys = Object.keys(data).filter(key => key.includes("_model"));
-    if( modelKeys.includes("display_model")) {
-	let position = modelKeys.indexOf("display_model");
-	modelKeys.splice(position, 1);
-    }
-    
   return (
     <TableContainer className='table-component' component={Paper}>
       <h3>Models:</h3>
-      <Table aria-label="simple table">
+      <Table aria-label='models table'>
         <TableHead>
           <TableRow>
-            <TableCell align="left"><b>Name</b></TableCell>
-            <TableCell align="left"><b>Polynomials</b></TableCell>
-            <TableCell align="left"><b>Resultant</b></TableCell>
-            <TableCell align="left"><b>Primes of Bad Reduction</b></TableCell>
-            <TableCell align="left"><b>Conjugation from Standard</b></TableCell>
+            <TableCell><b>Name</b></TableCell>
+            <TableCell><b>Polynomials</b></TableCell>
+            <TableCell><b>Resultant</b></TableCell>
+            <TableCell><b>Primes of Bad Reduction</b></TableCell>
+            <TableCell><b>Conjugation from Standard</b></TableCell>
+            <TableCell><b>Field of Definition</b></TableCell>
           </TableRow>
         </TableHead>
         <TableBody>
-          {modelKeys.map((key, index) => {
-            const modelData = data[key] ? splitOutermostCommas(data[key]) : ['', '', '', '', '']; // Split data[key] or set default values if null
-	    console.log("THIS SHIT RIGHT HERE: ");
-	    console.log(modelData[0]);
-	    console.log(processInput(modelData[0]));
+          {relevantModels.map((key, index) => {
+            const modelData = data[key] ? splitOutermostCommas(data[key]) : ['', '', '', '', ''];
             return (
               <TableRow key={index}>
-                <TableCell align="left">{key.replace(/_/g, ' ').replace(/ model$/, '') + " model"}</TableCell>
-                <TableCell align="left">{renderExponent(processInput(modelData[0]))}</TableCell>
-                <TableCell align="left">{modelData[1]}</TableCell>
-                <TableCell align="left">{modelData[2]}</TableCell>
-                <TableCell align="left">{modelData[5]}</TableCell>
+                <TableCell>{key.replace(/_/g, ' ').replace(/ model$/, '') + ' model'}</TableCell>
+                <TableCell>{renderExponent(processInput(modelData[0]))}</TableCell>
+                <TableCell>{modelData[1]}</TableCell>
+                <TableCell>{modelData[2]}</TableCell>
+                <TableCell>{modelData[5]}</TableCell>
+                <TableCell>{data.cp_field_of_defn || 'N/A'}</TableCell>
               </TableRow>
             );
           })}
@@ -139,23 +114,3 @@ export default function ModelsTable({ data }) {
     </TableContainer>
   );
 }
-
-// Function to split the string at the outermost commas
-export const splitOutermostCommas = (str) => {
-  const parts = [];
-  let temp = '';
-  let openBrackets = 0;
-  for (let i = 0; i < str.length; i++) {
-    if (str[i] === '{') openBrackets++;
-    else if (str[i] === '}') openBrackets--;
-    if (str[i] === ',' && openBrackets === 0) {
-      parts.push(temp.trim().replace(/["()]/g, '')); // Remove parentheses, curly braces, and double quotes
-      temp = '';
-    } else {
-      temp += str[i];
-    }
-  }
-  parts.push(temp.trim().replace(/["()]/g, '')); // Push the last part and remove characters
-  return parts;
-};
-

--- a/Frontend/src/pages/ExploreSystems.js
+++ b/Frontend/src/pages/ExploreSystems.js
@@ -731,7 +731,7 @@ function ExploreSystems() {
                                           x[2],
                                           x[3],
                                           <Link
-                                              to ={`https://www.lmfdb.org/NumberFields/${x[4]}`} 
+                                              to={`https://www.lmfdb.org/NumberField/${x[4]}`}
                                               style={{
                                                   color: "red",
                                                   textDecoration: "none",
@@ -740,7 +740,7 @@ function ExploreSystems() {
                                               rel="noopener noreferrer"
                                           >
                                               {x[4]}
-                                          </Link>
+                                          </Link>,
                                       ])
                             }
                             itemsPerPage={pagesPer}

--- a/Frontend/src/pages/ExploreSystems.js
+++ b/Frontend/src/pages/ExploreSystems.js
@@ -318,7 +318,7 @@ function ExploreSystems() {
                 <div className="results-container" container>
                     <Grid className="sidebar" item xs={3}>
                         <div style={{ marginLeft: "10px", marginRight: "10px" }}>
-                            <p class="sidebarHead">Filters</p>
+                            <p className="sidebarHead">Filters</p>
                             <Divider />
 
                             <ul id="myUL">
@@ -693,7 +693,7 @@ function ExploreSystems() {
                         >
                             Download
                         </span>
-			<label for="pages">Results Per Page:</label>	
+			<label htmlFor="pages">Results Per Page:</label>	
 			<select id="pages" name="pages"  value={pagesDisplay} onChange={handlePagePerChange}>
 			    <option value="10">10</option>
 			    <option value="20">20</option>
@@ -731,7 +731,7 @@ function ExploreSystems() {
                                           x[2],
                                           x[3],
                                           <Link
-                                              to={`https://www.lmfdb.org/NumberField/${x[4]}`}
+                                              to ={`https://www.lmfdb.org/NumberFields/${x[4]}`} 
                                               style={{
                                                   color: "red",
                                                   textDecoration: "none",
@@ -740,7 +740,7 @@ function ExploreSystems() {
                                               rel="noopener noreferrer"
                                           >
                                               {x[4]}
-                                          </Link>,
+                                          </Link>
                                       ])
                             }
                             itemsPerPage={pagesPer}
@@ -764,7 +764,7 @@ function ExploreSystems() {
 
                     <Grid className="sidebar" item xs={3}>
                         <div style={{ marginLeft: "10px", marginRight: "10px" }}>
-                            <p class="sidebarHead" >RESULT STATISTICS </p>
+                            <p className="sidebarHead" >RESULT STATISTICS </p>
                             <Divider />
 
                             <br />


### PR DESCRIPTION
Fixes #187 

**What's Changed?**

- Clickable Base Field Label: Turned base_field_label into a clickable link instead of plain text.

- Updated the Standard Model field in InfoTable.js to display the correct polynomial equation based on display_model. (I still struggle with this part. Now, it just displays the associated raw data of the standard model rather than an equation. The photo below as an example)

- Ensured that the Automorphism Group Cardinality field correctly displays its value in AutomorphismGroupTable.

**Why These Changes?**

Before, it was just text, so users couldn't click on it to access more information. This makes it much more useful.

- Previously, the Standard Model field just showed the standard model type instead of displaying the polynomial equation of the standard model based on display_model.

- The cardinality field was not explicitly verified before. I just need to confirm it displays correctly. 

**How?**

- Similarly, in ModelsTable.js, in InfoTable.js I wrapped base_field_label in an </a> tag. and added target="_blank" and rel="noopener noreferrer" for security. I also made it red too.

- I reused processInput and renderExponent from ModelsTable.js to format polynomial models, but the tricky part is also making sure non-polynomial ones still display correctly. My idea is if is_polynomial is true, grab and format models[display_model].polys_val; otherwise, just show data.reduced_model (since only reduced_model isn't polynomial). The challenge now is that InfoTable.js only needs to show one model from display_model, unlike ModelsTable, which lists all. A possible solution is tweaking these functions to handle this one-model case properly.

- Just need to verify data.automorphism_group_cardinality if there's an undefined value.

<img width="947" alt="click" src="https://github.com/user-attachments/assets/dc5eb149-b734-40ce-a27e-951d401215f6" />

