### PR TITLE
Reformatted Family Details Page into two tables with citations sectio…

### DIFF
--- a/Frontend/src/pages/FamilyDetails.js
+++ b/Frontend/src/pages/FamilyDetails.js
@@ -17,131 +17,69 @@ function FamilyDetailsTable({ family }) {
       "8": "\u2078",
       "9": "\u2079"
     };
-  
-    // Helper function to convert a number to superscript
-    const toSuperscript = (num) => {
-      return String(num).split("").map(digit => superscripts[digit]).join("");
-    };
-  
-    // For your example input [[1,0,t], [0,0,1]], we want to form [x² + ty², y²]
+    const toSuperscript = (num) => String(num).split("").map(digit => superscripts[digit]).join("");
     let result = coeffs.map((poly, polyIndex) => {
       let terms = [];
       let degree = poly.length - 1;
-  
       for (let i = 0; i < poly.length; i++) {
         const coeff = poly[i];
         const xPower = degree - i;
-        const yPower = i;  // y power increases as x power decreases
-  
-        // Skip terms with coefficient "0"
+        const yPower = i;
         if (coeff === "0") continue;
-  
         let term = "";
-        
-        // Handle coefficient
-        if (coeff !== "1" || (xPower === 0 && yPower === 0)) {
-          term += coeff;
-        }
-  
-        // Add x term if needed
-        if (xPower > 0) {
-          term += "x";
-          if (xPower > 1) {
-            term += toSuperscript(xPower);
-          }
-        }
-  
-        // Add y term if needed
-        if (yPower > 0) {
-          term += "y";
-          if (yPower > 1) {
-            term += toSuperscript(yPower);
-          }
-        }
-  
+        if (coeff !== "1" || (xPower === 0 && yPower === 0)) term += coeff;
+        if (xPower > 0) term += "x" + (xPower > 1 ? toSuperscript(xPower) : "");
+        if (yPower > 0) term += "y" + (yPower > 1 ? toSuperscript(yPower) : "");
         terms.push(term);
       }
-  
       return terms.join(" + ") || "0";
     });
-  
-    // Wrap the result in square brackets
     return `[${result.join(", ")}]`;
   };
 
-  const formatCitations = (citations) => {
-    if (!Array.isArray(citations)) return 'N/A';
-    return citations.join(', ');
-  };
+  const formatCitations = (citations) => Array.isArray(citations) ? citations.join(', ') : 'N/A';
 
   return (
-    <TableContainer className='table-component' component={Paper}>
-      <h3>Family Details</h3>
-      <Table aria-label="family details table">
-        <TableBody>
-          <TableRow>
-            <TableCell component="th" scope="row"><b>Family ID</b></TableCell>
-            <TableCell align="right">{family[0]}</TableCell>
-          </TableRow>
-          <TableRow>
-            <TableCell component="th" scope="row"><b>Name</b></TableCell>
-            <TableCell align="right">{family[1]}</TableCell>
-          </TableRow>
-          <TableRow>
-            <TableCell component="th" scope="row"><b>Degree</b></TableCell>
-            <TableCell align="right">{family[2]}</TableCell>
-          </TableRow>
-          <TableRow>
-            <TableCell component="th" scope="row"><b>Num Parameters</b></TableCell>
-            <TableCell align="right">{family[3]}</TableCell>
-          </TableRow>
-          <TableRow>
-            <TableCell component="th" scope="row"><b>Model Coeffs</b></TableCell>
-            <TableCell align="right">{formatModelCoeffs(family[4])}</TableCell>
-          </TableRow>
-          <TableRow>
-            <TableCell component="th" scope="row"><b>Model Resultant</b></TableCell>
-            <TableCell align="right">{family[5]}</TableCell>
-          </TableRow>
-          <TableRow>
-            <TableCell component="th" scope="row"><b>Base Field Label</b></TableCell>
-            <TableCell align="right">{family[6]}</TableCell>
-          </TableRow>
-          <TableRow>
-            <TableCell component="th" scope="row"><b>Base Field Degree</b></TableCell>
-            <TableCell align="right">{family[7]}</TableCell>
-          </TableRow>
-          <TableRow>
-            <TableCell component="th" scope="row"><b>Sigma One</b></TableCell>
-            <TableCell align="right">{family[8]}</TableCell>
-          </TableRow>
-          <TableRow>
-            <TableCell component="th" scope="row"><b>Sigma Two</b></TableCell>
-            <TableCell align="right">{family[9]}</TableCell>
-          </TableRow>
-          <TableRow>
-            <TableCell component="th" scope="row"><b>Ordinal</b></TableCell>
-            <TableCell align="right">{family[10]}</TableCell>
-          </TableRow>
-          <TableRow>
-            <TableCell component="th" scope="row"><b>Citations</b></TableCell>
-            <TableCell align="right">{formatCitations(family[11])}</TableCell>
-          </TableRow>
-          <TableRow>
-            <TableCell component="th" scope="row"><b>Is Polynomial</b></TableCell>
-            <TableCell align="right">{family[12] ? 'Yes' : 'No'}</TableCell>
-          </TableRow>
-          <TableRow>
-            <TableCell component="th" scope="row"><b>Num Critical Points</b></TableCell>
-            <TableCell align="right">{family[13]}</TableCell>
-          </TableRow>
-          <TableRow>
-            <TableCell component="th" scope="row"><b>Automorphism Group Cardinality</b></TableCell>
-            <TableCell align="right">{family[14]}</TableCell>
-          </TableRow>
-        </TableBody>
-      </Table>
-    </TableContainer>
+    <>
+      <TableContainer className='table-component' component={Paper}>
+        <h3>General Information</h3>
+        <Table>
+          <TableBody>
+            {[['Name', family[1]], ['Degree', family[2]], ['Model Coeffs', formatModelCoeffs(family[4])],
+              ['Base Field Label', family[6]], ['Sigma One', family[8]], ['Sigma Two', family[9]]].map(([label, value]) => (
+              <TableRow key={label}>
+                <TableCell><b>{label}</b></TableCell>
+                <TableCell align="right">{value}</TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </TableContainer>
+      <TableContainer className='table-component' component={Paper}>
+        <h3>Properties</h3>
+        <Table>
+          <TableBody>
+            {[['Model Resultant', family[5]], ['Is Polynomial', family[12] ? 'Yes' : 'No'], 
+              ['Num Critical Points', family[13]], ['Automorphism Group Cardinality', family[14]]].map(([label, value]) => (
+              <TableRow key={label}>
+                <TableCell><b>{label}</b></TableCell>
+                <TableCell align="right">{value}</TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </TableContainer>
+      <TableContainer className='table-component' component={Paper}>
+        <h3>Citations</h3>
+        <Table>
+          <TableBody>
+            <TableRow>
+              <TableCell>{formatCitations(family[11])}</TableCell>
+            </TableRow>
+          </TableBody>
+        </Table>
+      </TableContainer>
+    </>
   );
 }
 
@@ -163,7 +101,6 @@ function FamilyDetails() {
         setLoading(false);
       }
     };
-
     fetchFamily();
   }, [familyId]);
 

--- a/Frontend/src/pages/FamilyDetails.js
+++ b/Frontend/src/pages/FamilyDetails.js
@@ -1,12 +1,11 @@
 import React, { useState, useEffect } from 'react';
 import { useParams } from 'react-router-dom';
 import { get_family } from '../api/routes';
-import { Table, TableBody, TableCell, TableContainer, TableRow, Paper } from '@mui/material';
+import { Table, TableBody, TableCell, TableContainer, TableHead, TableRow, Paper } from '@mui/material';
 
 function FamilyDetailsTable({ family }) {
   const formatModelCoeffs = (coeffs) => {
-    const superscripts = {
-      "0": "\u2070",
+    const superscripts = {"0": "\u2070",
       "1": "\u00B9",
       "2": "\u00B2",
       "3": "\u00B3",
@@ -15,8 +14,8 @@ function FamilyDetailsTable({ family }) {
       "6": "\u2076",
       "7": "\u2077",
       "8": "\u2078",
-      "9": "\u2079"
-    };
+      "9": "\u2079"};
+
     const toSuperscript = (num) => String(num).split("").map(digit => superscripts[digit]).join("");
     let result = coeffs.map((poly, polyIndex) => {
       let terms = [];
@@ -37,35 +36,53 @@ function FamilyDetailsTable({ family }) {
     return `[${result.join(", ")}]`;
   };
 
-  const formatCitations = (citations) => Array.isArray(citations) ? citations.join(', ') : 'N/A';
+  const formatCitations = (citations) => Array.isArray(citations) ? citations.join(', ') : 'None';
 
   return (
     <>
       <TableContainer className='table-component' component={Paper}>
         <h3>General Information</h3>
         <Table>
+          <TableHead>
+            <TableRow>
+              <TableCell><b>Name</b></TableCell>
+              <TableCell><b>Degree</b></TableCell>
+              <TableCell><b>Model Coeffs</b></TableCell>
+              <TableCell><b>Base Field Label</b></TableCell>
+              <TableCell><b>Sigma One</b></TableCell>
+              <TableCell><b>Sigma Two</b></TableCell>
+            </TableRow>
+          </TableHead>
           <TableBody>
-            {[['Name', family[1]], ['Degree', family[2]], ['Model Coeffs', formatModelCoeffs(family[4])],
-              ['Base Field Label', family[6]], ['Sigma One', family[8]], ['Sigma Two', family[9]]].map(([label, value]) => (
-              <TableRow key={label}>
-                <TableCell><b>{label}</b></TableCell>
-                <TableCell align="right">{value}</TableCell>
-              </TableRow>
-            ))}
+            <TableRow>
+              <TableCell>{family[1]}</TableCell>
+              <TableCell>{family[2]}</TableCell>
+              <TableCell>{formatModelCoeffs(family[4])}</TableCell>
+              <TableCell>{family[6]}</TableCell>
+              <TableCell>{family[8]}</TableCell>
+              <TableCell>{family[9]}</TableCell>
+            </TableRow>
           </TableBody>
         </Table>
       </TableContainer>
       <TableContainer className='table-component' component={Paper}>
-        <h3>Properties</h3>
+        <h3>Mathematical Properties</h3>
         <Table>
+          <TableHead>
+            <TableRow>
+              <TableCell><b>Model Resultant</b></TableCell>
+              <TableCell><b>Is Polynomial</b></TableCell>
+              <TableCell><b>Num Critical Points</b></TableCell>
+              <TableCell><b>Automorphism Group Cardinality</b></TableCell>
+            </TableRow>
+          </TableHead>
           <TableBody>
-            {[['Model Resultant', family[5]], ['Is Polynomial', family[12] ? 'Yes' : 'No'], 
-              ['Num Critical Points', family[13]], ['Automorphism Group Cardinality', family[14]]].map(([label, value]) => (
-              <TableRow key={label}>
-                <TableCell><b>{label}</b></TableCell>
-                <TableCell align="right">{value}</TableCell>
-              </TableRow>
-            ))}
+            <TableRow>
+              <TableCell>{family[5]}</TableCell>
+              <TableCell>{family[12] ? 'Yes' : 'No'}</TableCell>
+              <TableCell>{family[13]}</TableCell>
+              <TableCell>{family[14]}</TableCell>
+            </TableRow>
           </TableBody>
         </Table>
       </TableContainer>


### PR DESCRIPTION
Fixes #192

**What was changed?**
The Family Details Page was reformatted to match the System Details Page structure. This was done by creating two distinct tables with the current data. Also a Citation table was added.

**Why was it changed?**
The previous layout did not match the rest of the program, leading to inconsistencies in the UI. This change makes the page easier to read. 

**How was it changed?**
Two distinct tables were created, to divide the data in a more organized manner. As well as adding a Citations table at the bottom of the page. All of this work was done in the FamilyDetails.js file.