### PR TITLE
Fixed Issue 193: Added Mathematical Term Definitions Across All Pages with Custom Component

### DIFF
--- a/Frontend/src/components/FunctionDetail/AutomorphismGroupTable.js
+++ b/Frontend/src/components/FunctionDetail/AutomorphismGroupTable.js
@@ -5,15 +5,20 @@ import TableCell from '@mui/material/TableCell';
 import TableContainer from '@mui/material/TableContainer';
 import TableRow from '@mui/material/TableRow';
 import Paper from '@mui/material/Paper';
+import HelpBox from '../FunctionDetail/HelpBox'
 
 export default function AutomorphismGroupTable({ data }) {
   return (
     <TableContainer className='table-component' component={Paper}>
       <h3>Automorphism Group</h3>
+      <h6>The groups of the function.</h6>
       <Table aria-label="simple table">
         <TableBody>
           <TableRow>
-            <TableCell component="th" scope="row"><b>Cardinality</b></TableCell>
+            <TableCell component="th" scope="row">
+              <b>Cardinality</b>
+              <HelpBox description="Shows how many elements are in the set." title="Cardinality" />
+            </TableCell>
             <TableCell align="right">
               {data.automorphism_group_cardinality !== undefined 
               ? data.automorphism_group_cardinality 
@@ -21,15 +26,24 @@ export default function AutomorphismGroupTable({ data }) {
             </TableCell>
           </TableRow>
           <TableRow>
-            <TableCell component="th" scope="row"><b>Structure</b></TableCell>
+            <TableCell component="th" scope="row">
+              <b>Structure</b>
+              <HelpBox description="The structure of the function." title="Structure" />
+            </TableCell>
             <TableCell align="right">{"trivial"}</TableCell>
           </TableRow>
           <TableRow>
-            <TableCell component="th" scope="row"><b>As Matrices</b></TableCell>
+            <TableCell component="th" scope="row">
+              <b>As Matrices</b>
+              <HelpBox description="The matrix." title="As Matrices" />
+            </TableCell>
             <TableCell align="right">{"link"}</TableCell>
           </TableRow>
           <TableRow>
-            <TableCell component="th" scope="row"><b>Field of Definition</b></TableCell>
+            <TableCell component="th" scope="row">
+              <b>Field of Definition</b>
+              <HelpBox description="HD or 1080p" title="Field of Definition" />
+            </TableCell>
             <TableCell align="right">{"QQ"}</TableCell>
           </TableRow>
         </TableBody>

--- a/Frontend/src/components/FunctionDetail/CriticalPointPortraitTable.js
+++ b/Frontend/src/components/FunctionDetail/CriticalPointPortraitTable.js
@@ -7,6 +7,7 @@ import TableRow from '@mui/material/TableRow';
 import Paper from '@mui/material/Paper';
 import AdjacencyMatrix from '../FunctionDetail/AdjacencyMatrix'
 import Copy from '../FunctionDetail/Copy'
+import HelpBox from '../FunctionDetail/HelpBox'
 
 export default function CriticalPointPortraitTable({ data }) {
   const formatData = (key) => {
@@ -34,24 +35,37 @@ export default function CriticalPointPortraitTable({ data }) {
     return (
       <TableContainer className='table-component' component={Paper}>
         <h3>Critical Point Portrait</h3>
+        <h6>The critical points of the portrait.</h6>
         <Table aria-label="simple table">
           <TableBody>
             <TableRow>
-              <TableCell component="th" scope="row"><b>Cardinality</b></TableCell>
+              <TableCell component="th" scope="row">
+                <b>Cardinality</b>
+                <HelpBox description="The cardinality shows how many elements are there." title="Cardinality" />
+              </TableCell>
               <TableCell align="right">{formatData("cardinality")}</TableCell>
             </TableRow>
             <TableRow>
-              <TableCell component="th" scope="row"><b>Size of Post Critical Set</b></TableCell>
+              <TableCell component="th" scope="row">
+                <b>Size of Post Critical Set</b>
+                <HelpBox description="Shows how many elements are in the post critical set." title="Size of Post Critical Set" />
+              </TableCell>
               <TableCell align="right">{formatData("positive_in_degree")}</TableCell>
             </TableRow>
             <TableRow>
-              <TableCell component="th" scope="row"><b>As Directed Graph</b></TableCell>
+              <TableCell component="th" scope="row">
+                <b>As Directed Graph</b>
+                <HelpBox description="Shows the data as a graph." title="As Directed Graph" />
+              </TableCell>
               <TableCell align="right">
                   <Copy edges={formatData("edges")} type={2} />
               </TableCell>
             </TableRow>
             <TableRow>
-              <TableCell component="th" scope="row"><b>Adjacency Matrix</b></TableCell>
+              <TableCell component="th" scope="row">
+                <b>Adjacency Matrix</b>
+                <HelpBox description="Generates a matrix based on the given data." title="Adjancency Matrix" />
+              </TableCell>
               <TableCell align="right">
                   <Copy edges={formatData("edges")} type={1} />
                   <br>
@@ -60,11 +74,17 @@ export default function CriticalPointPortraitTable({ data }) {
                 </TableCell>
             </TableRow>
             <TableRow>
-              <TableCell component="th" scope="row"><b>Cycle Lengths</b></TableCell>
+              <TableCell component="th" scope="row">
+                <b>Cycle Lengths</b>
+                <HelpBox description="Shows how many times you can go around in a cycle." title="Cycle Lengths" />
+              </TableCell>
               <TableCell align="right">{formatData("periodic_cycles")}</TableCell>
             </TableRow>
             <TableRow>
-              <TableCell component="th" scope="row"><b>Component Sizes</b></TableCell>
+              <TableCell component="th" scope="row">
+                <b>Component Sizes</b>
+                <HelpBox description="The size of the matrix idk." title="Component Sizes" />
+              </TableCell>
               <TableCell align="right">{formatData("preperiodic_components")}</TableCell>
             </TableRow>
           </TableBody>

--- a/Frontend/src/components/FunctionDetail/CriticalPointsTable.js
+++ b/Frontend/src/components/FunctionDetail/CriticalPointsTable.js
@@ -5,23 +5,34 @@ import TableCell from '@mui/material/TableCell';
 import TableContainer from '@mui/material/TableContainer';
 import TableRow from '@mui/material/TableRow';
 import Paper from '@mui/material/Paper';
+import HelpBox from '../FunctionDetail/HelpBox'
 
 export default function CriticalPointsTable({ data }) {
   return (
     <TableContainer className='table-component' component={Paper}>
       <h3>Critical Points</h3>
+      <h6>Where the function crosses zero.</h6>
       <Table aria-label="simple table">
         <TableBody>
           <TableRow>
-            <TableCell component="th" scope="row"><b>Postcritically Finite?</b></TableCell>
+            <TableCell component="th" scope="row">
+              <b>Postcritically Finite?</b>
+              <HelpBox description="Shows if the function is finite or whatever." title="Postcritically Finite?" />
+            </TableCell>
             <TableCell align="right">{String(data.is_pcf)}</TableCell>
           </TableRow>
           <TableRow>
-            <TableCell component="th" scope="row"><b>Critical Points Cardinality</b></TableCell>
+            <TableCell component="th" scope="row">
+              <b>Critical Points Cardinality</b>
+              <HelpBox description="Shows the number of critical points." title="Critical Points Cardinality" />
+            </TableCell>
             <TableCell align="right">{data.cp_cardinality || "N/A"}</TableCell>
           </TableRow>
           <TableRow>
-            <TableCell component="th" scope="row"><b>Field of Definition</b></TableCell>
+            <TableCell component="th" scope="row">
+              <b>Field of Definition</b>
+              <HelpBox description="The field of definition." title="Field of Definition" />
+            </TableCell>
             <TableCell align="right">{data.cp_field_of_defn || "N/A"}</TableCell>
           </TableRow>
         </TableBody>

--- a/Frontend/src/components/FunctionDetail/FunctionAttributes.js
+++ b/Frontend/src/components/FunctionDetail/FunctionAttributes.js
@@ -5,6 +5,7 @@ import TableCell from '@mui/material/TableCell';
 import TableContainer from '@mui/material/TableContainer';
 import TableRow from '@mui/material/TableRow';
 import Paper from '@mui/material/Paper';
+import HelpBox from '../FunctionDetail/HelpBox'
 
 export default function FunctionAttributes({ data }) {
   const Superscript = ({ children }) => (
@@ -64,15 +65,16 @@ export default function FunctionAttributes({ data }) {
   return (
     <TableContainer component={Paper} className="table-component">
       <h3>Function Attributes</h3>
+      <h6>The attributes of the function.</h6>
       <Table aria-label="function attributes table">
         <TableBody>
           {/* Row for field labels */}
           <TableRow>
-            <TableCell><b>Is Newton Function</b></TableCell>
-            <TableCell><b>Is Polynomial</b></TableCell>
-            <TableCell><b>Is Postcritically Finite (PCF)</b></TableCell>
-            <TableCell><b>Is Lattès Function</b></TableCell>
-            <TableCell><b>Is Chebyshev</b></TableCell>
+            <TableCell><b>Is Newton Function</b><HelpBox description="Did Newton eat the apple?" title="Is Newton Function" /></TableCell>
+            <TableCell><b>Is Polynomial</b><HelpBox description="Is it a polynomial?" title="Is Polynomial" /></TableCell>
+            <TableCell><b>Is Postcritically Finite (PCF)</b><HelpBox description="Is Postcritically Finite (PCF)" title="Is Postcritically Finite (PCF)" /></TableCell>
+            <TableCell><b>Is Lattès Function</b><HelpBox description="I am lactose intolerant." title="Is Lattès Function" /></TableCell>
+            <TableCell><b>Is Chebyshev</b><HelpBox description="I have no idea what this means." title="Is Chebyshev" /></TableCell>
             {data.is_newton && <TableCell><b>Associated Polynomial</b></TableCell>}
           </TableRow>
           {/* Row for values */}

--- a/Frontend/src/components/FunctionDetail/HelpBox.js
+++ b/Frontend/src/components/FunctionDetail/HelpBox.js
@@ -1,0 +1,19 @@
+import * as React from 'react';
+import { Tooltip, IconButton, Typography } from '@mui/material';
+import HelpIcon from '@mui/icons-material/Help';
+
+export default function HelpBox({description, title}) {
+    return (
+        <Tooltip title = {
+            <div>
+                {title && <Typography variant='subtitle1'><b>{title}</b></Typography>}
+                <Typography variant='body2'>{description}</Typography>
+            </div>
+        }
+        arrow enterTouchDelay={0} leaveTouchDelay={300000}>
+            <IconButton>
+                <HelpIcon/>
+            </IconButton>
+        </Tooltip>
+    );
+}

--- a/Frontend/src/components/FunctionDetail/InfoTable.js
+++ b/Frontend/src/components/FunctionDetail/InfoTable.js
@@ -8,6 +8,7 @@ import TableRow from '@mui/material/TableRow';
 import Paper from '@mui/material/Paper';
 import { useNavigate } from 'react-router-dom';
 import { processInput, renderExponent, splitOutermostCommas } from './ModelsTable';
+import HelpBox from '../FunctionDetail/HelpBox'
 
 
 export default function InfoTable({ data }) {
@@ -53,15 +54,16 @@ export default function InfoTable({ data }) {
   return (
     <TableContainer className='table-component' component={Paper}>
       <h3>Function Details</h3>
+      <h6>The details of the function.</h6>
       <Table aria-label="simple table">
         <TableHead>
           <TableRow>
-            <TableCell><b>Label</b></TableCell>
-            <TableCell align="right"><b>Domain</b></TableCell>
-            <TableCell align="right"><b>Standard Model</b></TableCell>
-            <TableCell align="right"><b>Degree</b></TableCell>
-            <TableCell align="right"><b>Field of Definition</b></TableCell>
-            <TableCell align="right"><b>Family</b></TableCell>
+            <TableCell><b>Label</b><HelpBox description="Label" title="Label" /></TableCell>
+            <TableCell align="right"><b>Domain</b><HelpBox description="Domain" title="Domain" /></TableCell>
+            <TableCell align="right"><b>Standard Model</b><HelpBox description="Standard Model" title="Standard Model" /></TableCell>
+            <TableCell align="right"><b>Degree</b><HelpBox description="Degree" title="Degree" /></TableCell>
+            <TableCell align="right"><b>Field of Definition</b><HelpBox description="Field of Definition" title="Field of Definition" /></TableCell>
+            <TableCell align="right"><b>Family</b><HelpBox description="Family" title="Family" /></TableCell>
           </TableRow>
         </TableHead>
         <TableBody>

--- a/Frontend/src/components/FunctionDetail/ModelsTable.js
+++ b/Frontend/src/components/FunctionDetail/ModelsTable.js
@@ -6,6 +6,7 @@ import TableContainer from '@mui/material/TableContainer';
 import TableHead from '@mui/material/TableHead';
 import TableRow from '@mui/material/TableRow';
 import Paper from '@mui/material/Paper';
+import HelpBox from '../FunctionDetail/HelpBox'
 
 export const renderExponent = (expressionArray) => {
 	const Superscript = ({ children }) => (
@@ -84,15 +85,16 @@ export default function ModelsTable({ data }) {
   return (
     <TableContainer className='table-component' component={Paper}>
       <h3>Models:</h3>
+      <h6>The different models of the function.</h6>
       <Table aria-label='models table'>
         <TableHead>
           <TableRow>
-            <TableCell><b>Name</b></TableCell>
-            <TableCell><b>Polynomials</b></TableCell>
-            <TableCell><b>Resultant</b></TableCell>
-            <TableCell><b>Primes of Bad Reduction</b></TableCell>
-            <TableCell><b>Conjugation from Standard</b></TableCell>
-            <TableCell><b>Field of Definition</b></TableCell>
+            <TableCell><b>Name</b><HelpBox description="Family" title="Name" /></TableCell>
+            <TableCell><b>Polynomials</b><HelpBox description="Family" title="Polynomials" /></TableCell>
+            <TableCell><b>Resultant</b><HelpBox description="Family" title="Resultant" /></TableCell>
+            <TableCell><b>Primes of Bad Reduction</b><HelpBox description="Family" title="Primes of Bad Reduction" /></TableCell>
+            <TableCell><b>Conjugation from Standard</b><HelpBox description="Family" title="Cojugation from Standard" /></TableCell>
+            <TableCell><b>Field of Definition</b><HelpBox description="Family" title="Field of Definition" /></TableCell>
           </TableRow>
         </TableHead>
         <TableBody>

--- a/Frontend/src/components/FunctionDetail/MultiplierInvariantsTable.js
+++ b/Frontend/src/components/FunctionDetail/MultiplierInvariantsTable.js
@@ -7,6 +7,7 @@ import TableContainer from '@mui/material/TableContainer';
 import TableHead from '@mui/material/TableHead';
 import TableRow from '@mui/material/TableRow';
 import Paper from '@mui/material/Paper';
+import HelpBox from '../FunctionDetail/HelpBox'
 
 function createData(period, invariants) {
   return { period, invariants };
@@ -22,11 +23,12 @@ export default function InfoTable() {
   return (
     <TableContainer className='table-component' component={Paper}>
       <h3>Multiplier Invariants (Sigma)</h3>
+      <h6>Invariants of the function.</h6>
       <Table aria-label="simple table">
         <TableHead>
           <TableRow>
-            <TableCell align="right"><b>Period</b></TableCell>
-            <TableCell align="right"><b>Invariants</b></TableCell>
+            <TableCell align="right"><b>Period</b><HelpBox description="Period" title="Period" /></TableCell>
+            <TableCell align="right"><b>Invariants</b><HelpBox description="Invariants" title="Invariants" /></TableCell>
           </TableRow>
         </TableHead>
         <TableBody>

--- a/Frontend/src/components/FunctionDetail/RationalPointsTable.js
+++ b/Frontend/src/components/FunctionDetail/RationalPointsTable.js
@@ -7,7 +7,7 @@ import TableRow from '@mui/material/TableRow';
 import Paper from '@mui/material/Paper';
 import AdjacencyMatrix from '../FunctionDetail/AdjacencyMatrix'
 import Copy from '../FunctionDetail/Copy'
-
+import HelpBox from '../FunctionDetail/HelpBox'
 
 export default function RationalPointsTable({ data }) {
 	console.log('rational pre data',data)
@@ -27,33 +27,34 @@ export default function RationalPointsTable({ data }) {
 		<>
 			<TableContainer className='table-component' component={Paper}>
 				<h3>Rational Preperiodic Points</h3>
+				<h6>The preperiodic points of the function.</h6>
 				<Table aria-label="simple table">
 					<TableBody>
 						<TableRow>
-							<TableCell component="th" scope="row"><b>Cardinality</b></TableCell>
+							<TableCell component="th" scope="row"><b>Cardinality</b><HelpBox description="Cardinality" title="Cardinality" /></TableCell>
 							<TableCell align="right">{data.cardinality}</TableCell>
 						</TableRow>
 						<TableRow>
-							<TableCell component="th" scope="row"><b>Field Label</b></TableCell>
+							<TableCell component="th" scope="row"><b>Field Label</b><HelpBox description="Family" title="Field Label" /></TableCell>
 							<TableCell align="right">{data.base_field_label}</TableCell>
 						</TableRow>
 						<TableRow>
-							<TableCell component="th" scope="row"><b>Preperiodic Components</b></TableCell>
+							<TableCell component="th" scope="row"><b>Preperiodic Components</b><HelpBox description="Family" title="Preperiodic Components" /></TableCell>
 							<TableCell align="right">{formatData('preperiodic_components')}</TableCell>
 						</TableRow>
 						<TableRow>
-							<TableCell component="th" scope="row"><b>Rational Preperiodic Points</b></TableCell>
+							<TableCell component="th" scope="row"><b>Rational Preperiodic Points</b><HelpBox description="Family" title="Rational Preperiodic Points" /></TableCell>
 							<TableCell align="right">{formatData('rational_periodic_points')}</TableCell>
 						</TableRow>
 						<TableRow>
-							<TableCell component="th" scope="row"><b>As Directed Graph</b></TableCell>
+							<TableCell component="th" scope="row"><b>As Directed Graph</b><HelpBox description="As Directed Graph" title="As Directed Graph" /></TableCell>
 							<TableCell align="right">
 								<Copy edges={formatData("edges")} type={2} />
 							</TableCell>
 								
 						</TableRow>
 						<TableRow>
-							<TableCell component="th" scope="row"><b>Adjacency Matrix</b></TableCell>
+							<TableCell component="th" scope="row"><b>Adjacency Matrix</b><HelpBox description="Family" title="Adjancency Matrix" /></TableCell>
 							<TableCell align="right">
 								<Copy edges={formatData("edges")} type={1} />
 								<br>


### PR DESCRIPTION
Fixes #193 

**What was changed?**

To make the website easier to use for the general public, I created a HelpBox component that can be used to show a tooltip (popup) of a definition or explanation. You can hover/click on the help icon, and a popup with the definition pops up. I designed it in a way that it will look and work well on both desktop and mobile devices. The HelpBox component can be modified, so you don't have to go to every file that uses the HelpBox to update it.

In addition, I added subtitles to the tables to help explain the purpose of the table better. I also manually added the help buttons and subtitles to 8 different tables.

Note that placeholder text is used for the tooltips and table subtitles. I will get in touch with our client, Dr. Hutz, soon to get real definitions and explanations.

**Why was it changed?**

First, this solves the issue 193, to add math definitions. Second, it will make the website easier to use and understand, since people can understand what each table row means or what a math term on the website means. Third, I remembered that one of Dr. Hutz's top needs was the definitions/explanations, so that's why I prioritized adding easily-accessible definitions across all the tables.

**How was it changed?**
So I created my own custom HelpBox component, which uses the Tooltip, IconButton, and Typography components of the React Material UI library, which was already used in the project. I designed the HelpBox to be accessible from both desktop and mobile devices, to futureproof it just in case we decide to have a mobile website in the future. Plus, we can customize the HelpBox without having to update every single page that uses it.

You can use the HelpBox in your code. Once you have a place to add the help button just add:
`<HelpBox description="The definition or explanation goes here" title="Optional title" />`
The description will show up in the tooltip, while the title (which is optional) will be in bold above the description. If you don't provide the title, the title just won't show up.
Remember to include `import HelpBox from '../FunctionDetail/HelpBox'` at the top of the React UI page to add my component in!

- On laptops and computers, you hover (put your mouse over) the help button for the box to show up. When you move your mouse away, the box disappears.
- On mobile devices, you click on the help button for the box to show up. When you click outside the box or automatically after 5 minutes, the box disappears.

I had to change a lot of files, since I manually updated 8 different tables to add the help buttons and subtitles. It took me a lot of time, but I wanted the website to be well-explained throughout. 

**Screenshots that show the changes (if applicable):**
![tool tip example](https://github.com/user-attachments/assets/a506a13b-1efa-4ed0-8594-025678a74770)
Here is an example of a help box.
![mobile tooltips](https://github.com/user-attachments/assets/5b38797c-62e9-47d9-b9d9-1284909ccc06)
The help box still works on mobile devices.
![help box throughout](https://github.com/user-attachments/assets/010fb62e-68b4-4b69-b987-55c3e03280d7)
I added help buttons to most of the tables on this website.