### PR TITLE
Added Search Functionality for Maps by Label, Sigma1, and Sigma2

### DIFF
--- a/Frontend/src/context/FilterContext.js
+++ b/Frontend/src/context/FilterContext.js
@@ -21,7 +21,10 @@ export const FilterProvider = ({ children }) => {
         base_field_degree: "",
         indeterminacy_locus_dimension: "",
         cp_cardinality: "",
-        periodic_cycles: ""
+        periodic_cycles: "",
+        sigma_one: "",
+        sigma_two: "",
+        label: ""
     });
 
     return (

--- a/Frontend/src/pages/ExploreSystems.js
+++ b/Frontend/src/pages/ExploreSystems.js
@@ -184,7 +184,10 @@ function ExploreSystems() {
                     num_components: filters.rationalPreperiodicComponents,
                     max_tail: filters.rationalPreperiodicLongestTail,
                     cp_cardinality: filters.cp_cardinality,
-                    positive_in_degree: filters.positive_in_degree
+                    positive_in_degree: filters.positive_in_degree,
+                    sigma_one: filters.sigma_one,
+                    sigma_two: filters.sigma_two,
+                    label: filters.label
                 }
             )
             setSystems(result.data['results']);
@@ -302,7 +305,10 @@ function ExploreSystems() {
         num_components: "",
         max_tail: "",
         cp_cardinality: "",
-        positive_in_degree: ""
+        positive_in_degree: "",
+        sigma_one: "",
+        sigma_two: "",
+        label: ""
     };
 
     let connectionStatus = true;
@@ -544,7 +550,7 @@ function ExploreSystems() {
                                     </ul>
                                 </li>
                             </ul>
- 
+
                             <ul id="myUL">
                                 <li>
                                     <span
@@ -658,10 +664,51 @@ function ExploreSystems() {
                                             value={filters.family.map((id) => families.find((option) => option.id === id))}
                                             onChange={handleAutocompleteChange}
                                         />)}
-                                        <br></br>
                                     </ul>
                                 </li>
                             </ul>
+
+                            <ul id="myUL">
+                                <li>
+                                    <span
+                                        className="caret"
+                                        onClick={toggleTree}
+                                    >
+                                        Other Map Properties
+                                    </span>
+                                    <ul className="nested">
+                                        <li>
+                                            <input
+                                                type="text"
+                                                style={textBoxStyle}
+                                                value={filters.sigma_one || ''}
+                                                onChange={(e) => handleTextChange("sigma_one", e.target.value)}
+                                            />
+                                            <label>Sigma 1</label>
+                                        </li>
+                                        <li>
+                                            <input
+                                                type="text"
+                                                style={textBoxStyle}
+                                                value={filters.sigma_two || ''}
+                                                onChange={(e) => handleTextChange("sigma_two", e.target.value)}
+                                            />
+                                            <label>Sigma 2</label>
+                                        </li>
+                                        <li>
+                                            <input
+                                                type="text"
+                                                style={textBoxStyle}
+                                                value={filters.label || ''}
+                                                onChange={(e) => handleTextChange("label", e.target.value)}
+                                            />
+                                            <label>Label</label>
+                                        </li>
+                                    </ul>
+                                </li>
+                            </ul>
+
+                            <br></br>
                             <ul id="myUL">
                               <li  style={{ paddingBottom: '10px' }}>
                                     <Button


### PR DESCRIPTION
Fixes #201 

**What was changed?**

Search functionality was added so the user can search and filter through the different maps via `label`, `sigma1`, or `sigma2`. I designed the search so it is flexible. It doesn't matter whether capital or lowercase letters are used, or if the user puts spaces before or after the search text -- that way the search can still work regardless of how someone types it in. You can also type part of the search term and the corresponding maps will still show up (e.g. typing `      PoOn    ` will still popup results for `Poonen1998`).

The search additions works with the existing UI layout, and also clears when you hit Clear Filters.

**Why was it changed?**

This directly solves issue 201, so the user is able to search and filter through the maps by `label`, `sigma1`, or `sigma2` properties. This gives users more control on searching and filtering.

**How was it changed?**

First, the `ExploreSystems.js` file was modified to add the UI search elements and associated filter code for `label`, `sigma1`, or `sigma2`.

This file then sends the search parameters, using Axios, to the Flask backend, where the `get_filtered_systems()` function is called. This function creates a SQL request and calls a separate function `build_where_text()` where the "where text" (to filter the database) is created. I modified this function so it also filters by label, sigma1, or sigma2. To make it not case-sensitive, I used the `ILIKE` operator, while I used `TRIM` to eliminate leading and trailing whitespace.

The thing that took me hours to figure out was the `label` field. The `label` field was in another table called `citations`. So I had to teach myself some SQL and have the SQL request also include the `citations` table when doing the search (using `LEFT JOIN`). Since there is a table and a data field both called `citations`, I had to create an alias (alternative name) for the `citations` table called `citationsTable`.

Even when doing that, the code didn't work, and after a few hours I figured out that the  `get_filtered_systems()` function also calls the `get_statistics()` function (which generates overall info). Since the `get_statistics()` function used the same "where text" but had its own SQL text, it failed since it didn't know what the `citations` table was. So I had to update the SQL requests in the `get_statistics()` function to include the alias and inclusion of the `citations` table.

I just included my experience so you won't make the same mistake. I also included comments as well in the code.

**Screenshots that show the changes (if applicable):**
In the below example, I am searching for maps with a `sigma1` containing `a6a`.
![search](https://github.com/user-attachments/assets/f20a8bb6-a53e-4212-8528-1f69c6e33d4a)
