### PR TITLE
Fixes: Display Curve Information for Lattes Maps and Associated Polynomial for Newton Maps

### DIFF
--- a/Frontend/src/components/FunctionDetail/InfoTable.js
+++ b/Frontend/src/components/FunctionDetail/InfoTable.js
@@ -50,18 +50,29 @@ export default function InfoTable({ data }) {
 
 
   let polynomialExpression;
+
+  // For Newton polynomial
   if (data.is_newton) {
-    polynomialExpression = data.newton_polynomial_coeffs.join(' + '); 
-    //in the dataset there's no is_newton is true and no value of newton_polynomial_coeffs
-    //so I don't know the format of it, will adjust if we have updated data
-  } else if (polynomial) {
-    const modelData = splitOutermostCommas(polynomial);
-    polynomialExpression = renderExponent(modelData[0]);
+    const newtonPolynomial = data.newton_polynomial_coeffs;
+    if (newtonPolynomial && newtonPolynomial.some(coeff => coeff !== null)) {
+      //for non-null, it's just my assumption about formatting
+      polynomialExpression = newtonPolynomial.map((coeff, index) => {
+        const exponentX = newtonPolynomial.length - 1 - index; 
+        const exponentY = index; 
+        let term = '';
+        if (coeff !== null && coeff !== 0) {
+          if (exponentX > 0) term += `x^${exponentX}`;
+          if (exponentY > 0) term += `y^${exponentY}`;
+          return coeff === 1 ? term : `${coeff}*${term}`;
+        }
+      }).filter(Boolean).join(' + ');
+    } 
   }
-  // if (polynomial) {
-  //   const modelData= splitOutermostCommas(polynomial);
-  //   polynomialExpression= renderExponent(processInput(modelData[0]));
-  // }
+  
+  if (polynomial) {
+    const modelData= splitOutermostCommas(polynomial);
+    polynomialExpression= renderExponent(processInput(modelData[0]));
+  }
   console.log("Standard Model Name:", standard_model);
   console.log("Model Key Used:", modelKey);
   console.log("Polynomial Data Found:", polynomial);

--- a/Frontend/src/components/FunctionDetail/InfoTable.js
+++ b/Frontend/src/components/FunctionDetail/InfoTable.js
@@ -41,11 +41,27 @@ export default function InfoTable({ data }) {
     polynomial= data[`${standard_model}_model`];
   }
 
+  const labelDisplay = data.is_lattes ? (
+    <a href={`https://www.lmfdb.org/EllipticCurve/${data.sigma_one}`} target="_blank" rel="noopener noreferrer">
+      {data.sigma_one}
+    </a>
+  ) : data.modelLabel;
+
+
+
   let polynomialExpression;
-  if (polynomial) {
-    const modelData= splitOutermostCommas(polynomial);
-    polynomialExpression= renderExponent(processInput(modelData[0]));
+  if (data.is_newton) {
+    polynomialExpression = data.newton_polynomial_coeffs.join(' + '); 
+    //in the dataset there's no is_newton is true and no value of newton_polynomial_coeffs
+    //so I don't know the format of it, will adjust if we have updated data
+  } else if (polynomial) {
+    const modelData = splitOutermostCommas(polynomial);
+    polynomialExpression = renderExponent(modelData[0]);
   }
+  // if (polynomial) {
+  //   const modelData= splitOutermostCommas(polynomial);
+  //   polynomialExpression= renderExponent(processInput(modelData[0]));
+  // }
   console.log("Standard Model Name:", standard_model);
   console.log("Model Key Used:", modelKey);
   console.log("Polynomial Data Found:", polynomial);
@@ -68,7 +84,7 @@ export default function InfoTable({ data }) {
         </TableHead>
         <TableBody>
           <TableRow>
-            <TableCell component="th" scope="row">{data.modelLabel}</TableCell>
+            <TableCell component="th" scope="row">{labelDisplay}</TableCell> 
             <TableCell align="right">{data.base_field_label}</TableCell>
             <TableCell align="right">{polynomialExpression}</TableCell>
             <TableCell align="right">{data.degree}</TableCell>


### PR DESCRIPTION
Fixes #203 

**What was changed?**

- Check if is_lattes is true, the sigma_one value (curve label) is now displayed as a clickable link to the LMFDB page. (if not display modelLabel for Label column)

- Check if is_newton is true, the Newton polynomial is displayed using the newton_polynomial_coeffs.

**Why was it changed?**

- For Lattes: We need to display the sigma_one curve label as a clickable link to the LMFDB page.
- For Newton: We want to display the Newton polynomial using the available polynomial coefficients.

**How was it changed?**

- For Lattes: Added a check for is_lattes to display the sigma_one value as a clickable link
- For Newton: Added a check for is_newton to display the Newton polynomial:
- The default model label is displayed if neither is_lattes nor is_newton is true.

**Note:

- The LMFDB link for Lattes is a placeholder (https://www.lmfdb.org/EllipticCurve/${data.sigma_one}), which is not correct. I tried to click around but not sure what the correct link should be, I will update it when confirm the correct format one.
- There's no is_newton is true and newton_polynomial_coeffs is all null so I don't know the correct format of it. We can update the logic if we have updated dataset.

![image](https://github.com/user-attachments/assets/8c35ce0d-8aed-424e-ab6a-55abff91ab07)
