### PR TITLE
Refactored InfoTable to display family names instead of IDs (Fixes #200)

### DIFF
--- a/Frontend/src/components/FunctionDetail/FunctionAttributes.js
+++ b/Frontend/src/components/FunctionDetail/FunctionAttributes.js
@@ -76,6 +76,7 @@ export default function FunctionAttributes({ data }) {
             <TableCell><b>Is Lattès Function</b><HelpBox description="I am lactose intolerant." title="Is Lattès Function" /></TableCell>
             <TableCell><b>Is Chebyshev</b><HelpBox description="I have no idea what this means." title="Is Chebyshev" /></TableCell>
             {data.is_newton && <TableCell><b>Associated Polynomial</b></TableCell>}
+            <TableCell><b>Automorphism Cardinality</b><HelpBox description="Shows how many elements are in the set." title="Automorphism Cardinality" /></TableCell>
           </TableRow>
           {/* Row for values */}
           <TableRow>
@@ -85,6 +86,7 @@ export default function FunctionAttributes({ data }) {
             <TableCell>{String(data.is_lattes)}</TableCell>
             <TableCell>{String(data.is_chebyshev)}</TableCell>
             {data.is_newton && <TableCell>{newtonPolynomial}</TableCell>}
+            <TableCell>{data.automorphism_group_cardinality !== undefined ? data.automorphism_group_cardinality: "N/A"}</TableCell>
           </TableRow>
         </TableBody>
       </Table>

--- a/Frontend/src/components/FunctionDetail/InfoTable.js
+++ b/Frontend/src/components/FunctionDetail/InfoTable.js
@@ -50,6 +50,12 @@ export default function InfoTable({ data }) {
   console.log("Model Key Used:", modelKey);
   console.log("Polynomial Data Found:", polynomial);
 
+  // Map family_id values to there corresponding family names
+  const familyMapping = {
+    1: "poly_deg_2",
+    2: "poly_deg_3"
+  };
+
 
   return (
     <TableContainer className='table-component' component={Paper}>
@@ -93,7 +99,8 @@ export default function InfoTable({ data }) {
                     cursor: "pointer"
                   }}
                 >
-                  {data.family}
+                  {/* Displays the mapped family name*/}
+                  {familyMapping[data.family] || data.family}
                 </button>
               )}
             </TableCell>

--- a/Frontend/src/components/FunctionDetail/InfoTable.js
+++ b/Frontend/src/components/FunctionDetail/InfoTable.js
@@ -81,7 +81,10 @@ export default function InfoTable({ data }) {
             <TableCell align="right">
             <a
                 href={`https://www.lmfdb.org/NumberField/${data.base_field_label}`}
-                style={{ color: "blue", textDecoration: "underline" }}
+                style={{
+                  color: "blue",
+                  textDecoration: "underline"
+                }}
                 target="_blank"
                 rel="noopener noreferrer"
               >
@@ -94,7 +97,8 @@ export default function InfoTable({ data }) {
                   onClick={() => handleLinkClick(data.family)}
                   style={{
                     border: "None",
-                    color: "red",
+                    color: "blue",
+                    textDecoration: "underline",
                     backgroundColor: "rgba(0, 0, 0, 0)",
                     cursor: "pointer"
                   }}

--- a/Frontend/src/components/FunctionDetail/ModelsTable.js
+++ b/Frontend/src/components/FunctionDetail/ModelsTable.js
@@ -93,7 +93,6 @@ export default function ModelsTable({ data }) {
             <TableCell><b>Polynomials</b><HelpBox description="Family" title="Polynomials" /></TableCell>
             <TableCell><b>Resultant</b><HelpBox description="Family" title="Resultant" /></TableCell>
             <TableCell><b>Primes of Bad Reduction</b><HelpBox description="Family" title="Primes of Bad Reduction" /></TableCell>
-            <TableCell><b>Conjugation from Standard</b><HelpBox description="Family" title="Cojugation from Standard" /></TableCell>
             <TableCell><b>Field of Definition</b><HelpBox description="Family" title="Field of Definition" /></TableCell>
           </TableRow>
         </TableHead>
@@ -106,7 +105,6 @@ export default function ModelsTable({ data }) {
                 <TableCell>{renderExponent(processInput(modelData[0]))}</TableCell>
                 <TableCell>{modelData[1]}</TableCell>
                 <TableCell>{modelData[2]}</TableCell>
-                <TableCell>{modelData[5]}</TableCell>
                 <TableCell>{data.cp_field_of_defn || 'N/A'}</TableCell>
               </TableRow>
             );

--- a/Frontend/src/pages/SystemDetails.js
+++ b/Frontend/src/pages/SystemDetails.js
@@ -67,9 +67,6 @@ function SystemDetails() {
               <ModelsTable data = {data}/>
             </div>
             <div className="row">
-              <AutomorphismGroupTable data={data} />
-            </div>
-            <div className="row">
               <CitationsTable data = {data}/>
             </div>
         </div>


### PR DESCRIPTION
Fixes #200 

**What was changed?**
- The Conjugation from Standard column was removed.
- The Automorphism Group table was removed from the System Details page.
- The Family Name field in function details was changed to display the actual family name.

**Why was it changed?**
- The Conjugation column was removed because the data is no longer available. This creates a neater display for the user.
- The Automorphism Group table was removed because it no longer provides unique data. Doing this creates a neater display for the user.
- The Family name in function details now shows the actual family name instead of the data id reflecting it. This provides additional clarity for the user on family data.

**How was it changed?**
InfoTable.js, SystemDetails.js, and ModelsTable.js were modified. Primarily only lines were deleted to cut out non-useful data. But, some additions were made to InfoTable,js in order to maintain functionality of the family id and button.