### PR TITLE
Fixes: Update Rational Twists to Display Labels Instead of Function IDs

### DIFF
--- a/Frontend/src/components/FunctionDetail/RationalTwistsTable.js
+++ b/Frontend/src/components/FunctionDetail/RationalTwistsTable.js
@@ -21,7 +21,7 @@ export default function RationalTwistsTable({ data }) {
           </TableRow>
           {/* Data Row */}
           <TableRow>
-            <TableCell>{data.function_id}</TableCell>
+            <TableCell>{data.modelLabel}</TableCell>
             <TableCell>
               {data.rational_twists && data.rational_twists.length > 0 ? (
                 data.rational_twists.map((id, index) => (


### PR DESCRIPTION
Fixes #210 

**What was changed?**
Updated the Rational Twists table to show function labels instead of function IDs.

**Why was it changed?**
Function IDs are not user-friendly. Using the same labels as seen in other parts of the application makes the information more readable and consistent.

**How was it changed?**

- Use modelLabel property instead of function_id

- Update column header from "Function ID" to "Label"


