### PR TITLE
Fixes: Increase Size of Sigma and Label Fields in Filters Section

### DIFF
--- a/Frontend/src/components/FunctionDetail/RationalTwistsTable.js
+++ b/Frontend/src/components/FunctionDetail/RationalTwistsTable.js
@@ -16,7 +16,7 @@ export default function RationalTwistsTable({ data }) {
         <TableBody>
           {/* Header Row */}
           <TableRow>
-            <TableCell><b>Function ID</b></TableCell>
+            <TableCell><b>Label</b></TableCell>
             <TableCell><b>Rational Twists</b></TableCell>
           </TableRow>
           {/* Data Row */}

--- a/Frontend/src/components/FunctionDetail/RationalTwistsTable.js
+++ b/Frontend/src/components/FunctionDetail/RationalTwistsTable.js
@@ -21,7 +21,7 @@ export default function RationalTwistsTable({ data }) {
           </TableRow>
           {/* Data Row */}
           <TableRow>
-            <TableCell>{data.function_id}</TableCell>
+            <TableCell>{data.modelLabel}</TableCell>
             <TableCell>
               {data.rational_twists && data.rational_twists.length > 0 ? (
                 data.rational_twists.map((id, index) => (

--- a/Frontend/src/pages/ExploreSystems.js
+++ b/Frontend/src/pages/ExploreSystems.js
@@ -675,41 +675,38 @@ function ExploreSystems() {
                                     </span>
                                     <ul className="nested">
                                         <li>
+                                        <label>Sigma 1</label>
                                             <input
                                                 type="text"
-                                                style={textBoxStyle}
+                                                // style={textBoxStyle} if we want to apply the same style for all text boxes, we can adjust textBoxStyle
+                                                style={{ width: "150px", marginRight: "12px" }}
                                                 value={filters.sigma_one || ''}
                                                 onChange={(e) => handleTextChange("sigma_one", e.target.value)}
                                             />
-                                            <label>Sigma 1</label>
+                                            
                                         </li>
                                         <li>
+                                        <label>Sigma 2</label>
                                             <input
                                                 type="text"
-                                                style={textBoxStyle}
+                                                // style={textBoxStyle}
+                                                style={{ width: "150px", marginRight: "12px" }}
                                                 value={filters.sigma_two || ''}
                                                 onChange={(e) => handleTextChange("sigma_two", e.target.value)}
                                             />
-                                            <label>Sigma 2</label>
                                         </li>
                                         <li>
+                                        {/* <label>Label </label> */}
+                                        <label style={{ display: "block", marginBottom: "5px" }}>Label</label>
                                             <input
                                                 type="text"
-                                                style={textBoxStyle}
+                                                // style={textBoxStyle}
+                                                style={{ width: "150px", marginRight: "12px" }}
                                                 value={filters.model_label || ''}
                                                 onChange={(e) => handleTextChange("model_label", e.target.value)}
                                             />
-                                            <label>Label</label>
                                         </li>
-                                        <li>
-                                            <input
-                                                type="text"
-                                                style={textBoxStyle}
-                                                value={filters.journal_label || ''}
-                                                onChange={(e) => handleTextChange("journal_label", e.target.value)}
-                                            />
-                                            <label>Journal Label</label>
-                                        </li>
+                                         <li></li>   
                                     </ul>
                                 </li>
                             </ul>


### PR DESCRIPTION
Fixes #211 

**What was changed?**

Updated the layout of the Sigma 1, Sigma 2, and Label filter fields in the ExploreSystems component. Removed the Journal Label field.

**Why was it changed?**
The input fields were too small and hard to read. Journal Label is no longer required.

**How was it changed?**
In ExploreSystems.js:
- Increased input field widths to 150px.
- Positioned labels above their input fields
- Added proper spacing between fields
- Removed the Journal Label field completely

<img width="203" alt="Screenshot 2025-03-24 103954" src="https://github.com/user-attachments/assets/05a6eb45-ca22-4a07-bd37-3a1507746fe4" />

