### PR TITLE
Fix #218: Corrected data fields and outputed data for Function Detail…

### DIFF
--- a/Backend/postgres_connector.py
+++ b/Backend/postgres_connector.py
@@ -53,6 +53,33 @@ class PostgresConnector:
             if cur:
                 cur.close()
         return result
+    
+    def get_graph_metadata(self, graph_id):
+        sql = """
+            SELECT cardinality, periodic_cycles, preperiodic_components, max_tail
+            FROM graphs_dim_1_nf
+            WHERE graph_id = %s
+        """
+        try:
+            with self.connection.cursor() as cur:
+                cur.execute(sql, (graph_id,))
+                result = cur.fetchone()
+        except Exception:
+            self.connection.rollback()
+            result = None
+        finally:
+            if cur:
+                cur.close()
+
+        if result:
+            return {
+                'cardinality': result[0],
+                'periodic_cycles': result[1],
+                'preperiodic_components': result[2],
+                'max_tail': result[3],
+            }
+        else:
+            return {}
 
     def get_label(self, function_id):
         sql = """SELECT sigma_one, sigma_two, ordinal

--- a/Backend/postgres_connector.py
+++ b/Backend/postgres_connector.py
@@ -53,7 +53,7 @@ class PostgresConnector:
             if cur:
                 cur.close()
         return result
-    
+
     def get_graph_metadata(self, graph_id):
         sql = """
             SELECT cardinality, periodic_cycles, preperiodic_components, max_tail

--- a/Backend/server.py
+++ b/Backend/server.py
@@ -75,5 +75,17 @@ def data8():
     label = connector.get_label(function_id)
     return jsonify({'label': label})
 
+@app.route('/get_graph_metadata', methods=['POST'])
+def get_graph_metadata():
+    graph_id = request.get_json().get('graph_id')
+    if graph_id is None:
+        return jsonify({'error': 'graph_id is required'}), 400
+
+    try:
+        metadata = connector.get_graph_metadata(graph_id)
+        return jsonify(metadata)
+    except Exception as e:
+        return jsonify({'error': str(e)}), 500
+
 if __name__ == '__main__':
     app.run()

--- a/Frontend/src/api/routes.js
+++ b/Frontend/src/api/routes.js
@@ -51,3 +51,9 @@ export const get_label = (functionId) => axios({
     url: "http://127.0.0.1:5000/get_label",
     data: { function_id: functionId }
 });
+
+export const get_graph_metadata = (graphId) => axios({
+    method: "post",
+    url: "http://127.0.0.1:5000/get_graph_metadata",
+    data: { graph_id: graphId }
+});

--- a/Frontend/src/components/FunctionDetail/RationalPointsTable.js
+++ b/Frontend/src/components/FunctionDetail/RationalPointsTable.js
@@ -8,6 +8,7 @@ import TableHead from '@mui/material/TableHead';
 import TableRow from '@mui/material/TableRow';
 import Paper from '@mui/material/Paper';
 import { styled } from '@mui/material/styles';
+import { Box } from '@mui/material';
 import { get_rational_periodic_data, get_label, get_graph_metadata } from '../../api/routes';
 import AdjacencyMatrix from '../FunctionDetail/AdjacencyMatrix';
 import Copy from '../FunctionDetail/Copy';
@@ -80,36 +81,52 @@ export default function RationalPointsTable({ data }) {
           <TableHead>
             <TableRow>
               <TableCell>
-                <b>Field Label</b>
-                <HelpBox title="Field Label" description="An identifier representing the field extension the map is defined over, typically in a dot-separated form." />
+                <Box display="inline-flex" alignItems="center" gap={0.5}>
+                  <b>Field Label</b>
+                  <HelpBox title="Field Label" description="An identifier representing the field extension the map is defined over, typically in a dot-separated form." />
+                </Box>
               </TableCell>
               <TableCell>
-                <b>Cardinality</b>
-                <HelpBox title="Cardinality" description="The number of elements in the field over which the function is defined." />
+                <Box display="inline-flex" alignItems="center" gap={0.5}>
+                  <b>Cardinality</b>
+                  <HelpBox title="Cardinality" description="The number of elements in the field over which the function is defined." />
+                </Box>
               </TableCell>
               <TableCell>
-                <b>As Directed Graph</b>
-                <HelpBox title="As Directed Graph" description="Visual representation of the function as a directed graph showing how elements map under iteration." />
+                <Box display="inline-flex" alignItems="center" gap={0.5}>
+                  <b>As Directed Graph</b>
+                  <HelpBox title="As Directed Graph" description="Visual representation of the function as a directed graph showing how elements map under iteration." />
+                </Box>
               </TableCell>
               <TableCell>
-                <b>Adjacency Matrix</b>
-                <HelpBox title="Adjacency Matrix" description="The matrix representation of the directed graph where each entry indicates an edge between nodes." />
+                <Box display="inline-flex" alignItems="center" gap={0.5}>
+                  <b>Adjacency Matrix</b>
+                  <HelpBox title="Adjacency Matrix" description="The matrix representation of the directed graph where each entry indicates an edge between nodes." />
+                </Box>
               </TableCell>
               <TableCell>
-                <b>Cycle Lengths</b>
-                <HelpBox title="Cycle Lengths" description="Lengths of distinct cycles formed by rational periodic points under iteration." />
+                <Box display="inline-flex" alignItems="center" gap={0.5}>
+                  <b>Cycle Lengths</b>
+                  <HelpBox title="Cycle Lengths" description="Lengths of distinct cycles formed by rational periodic points under iteration." />
+                </Box>
               </TableCell>
               <TableCell>
-                <b>Component Sizes</b>
-                <HelpBox title="Component Sizes" description="Sizes of connected components in the directed graph formed by the function." />
+                <Box display="inline-flex" alignItems="center" gap={0.5}>
+                  <b>Component Sizes</b>
+                  <HelpBox title="Component Sizes" description="Sizes of connected components in the directed graph formed by the function." />
+                </Box>
               </TableCell>
               <TableCell>
-                <b>Rational Preperiodic Points</b>
-                <HelpBox title="Rational Preperiodic Points" description="Points defined over the rational field that eventually become periodic under iteration, along with their preperiod lengths." />
+                <Box display="inline-flex" alignItems="center" gap={0.5}>
+                  <b>Rational Preperiodic Points</b>
+                  <HelpBox title="Rational Preperiodic Points" description="Points defined over the rational field that eventually become periodic under iteration, along with their preperiod lengths." />
+                </Box>
               </TableCell>
               <TableCell>
-                <b>Longest Tail</b>
-                <HelpBox title="Longest Tail" description="The maximum preperiod length (number of steps before becoming periodic) among all preperiodic points." />
+                <Box display="inline-flex" alignItems="center" gap={0.5}>
+                  <b>Longest Tail</b>
+                  <HelpBox title="Longest Tail" description="The maximum preperiod length (number of steps before becoming periodic) among all preperiodic points." />
+                </Box>
               </TableCell>
             </TableRow>
           </TableHead>
@@ -119,23 +136,33 @@ export default function RationalPointsTable({ data }) {
               const meta = graphMetaMap[graphId] || {};
 
               return (
-                <TableRow key={index}>
-                  <TableCell>{item[2]}</TableCell>
-                  <TableCell>{meta.cardinality !== undefined && meta.cardinality !== null ? meta.cardinality : 'N/A'}</TableCell>
-                  <TableCell><Copy edges={formatData("edges")} type={2} /></TableCell>
-                  <TableCell>
-                    <AdjacencyMatrix modalTitle={"Adjacency Matrix"} edges={formatData("edges")} />
-                  </TableCell>
-                  <TableCell>{Array.isArray(meta.periodic_cycles) && meta.periodic_cycles.length > 0 ? `[${meta.periodic_cycles.join(', ')}]` : 'N/A'}</TableCell>
-                  <TableCell>{Array.isArray(meta.preperiodic_components) && meta.preperiodic_components.length > 0 ? `[${meta.preperiodic_components.join(', ')}]` : 'N/A'}</TableCell>
-                  <TableCell>
-                    {Array.isArray(item[3]) && item[3].length > 0 ? (item[3].map((point, idx) => (
-                        <div key={idx}>{`(${point[0]}, ${point[1]})`}</div>
-                      ))
-                    ) : ('N/A')}
-                  </TableCell>
-                  <TableCell>{meta.max_tail !== undefined && meta.max_tail !== null ? meta.max_tail : 'N/A'}</TableCell>
-                </TableRow>
+<TableRow key={index}>
+  <TableCell sx={{ width: '100px', maxWidth: '100px' }}>{item[2]}</TableCell>
+  <TableCell sx={{ width: '60px', maxWidth: '60px', textAlign: 'center' }}>{meta.cardinality !== undefined && meta.cardinality !== null ? meta.cardinality : 'N/A'}</TableCell>
+  <TableCell sx={{ width: '180px', maxWidth: '180px' }}>
+    <Box display="flex" flexDirection="column" alignItems="flex-start" gap={0.5}>
+      <Copy edges={formatData("edges")} type={2} size="small" sx={{ whiteSpace: 'nowrap' }} />
+    </Box>
+  </TableCell>
+  <TableCell sx={{ width: '220px', maxWidth: '220px' }}>
+    <Box display="flex" flexDirection="column" alignItems="flex-start" justifyContent="flex-start" gap={0.5}>
+      <Copy edges={formatData("edges")} type={1} size="small" sx={{ whiteSpace: 'nowrap' }} />
+      <AdjacencyMatrix modalTitle={"Adjacency Matrix"} edges={formatData("edges")} size="small" sx={{ whiteSpace: 'nowrap' }} />
+    </Box>
+  </TableCell>
+  <TableCell sx={{ width: '100px', maxWidth: '100px' }}>{Array.isArray(meta.periodic_cycles) && meta.periodic_cycles.length > 0 ? `[${meta.periodic_cycles.join(', ')}]` : 'N/A'}</TableCell>
+  <TableCell sx={{ width: '120px', maxWidth: '120px' }}>{Array.isArray(meta.preperiodic_components) && meta.preperiodic_components.length > 0 ? `[${meta.preperiodic_components.join(', ')}]` : 'N/A'}</TableCell>
+  <TableCell sx={{ width: '100px', maxWidth: '100px' }}>
+    {Array.isArray(item[3]) && item[3].length > 0 ? (
+      item[3].map((point, idx) => <div key={idx}>{`(${point[0]}, ${point[1]})`}</div>)
+    ) : ('N/A')}
+  </TableCell>
+  <TableCell sx={{ width: '60px', maxWidth: '60px', textAlign: 'center' }}>{meta.max_tail !== undefined && meta.max_tail !== null ? meta.max_tail : 'N/A'}</TableCell>
+</TableRow>
+
+
+
+
               );
             })}
           </TableBody>
@@ -144,3 +171,12 @@ export default function RationalPointsTable({ data }) {
     </>
   );
 }
+
+
+
+
+
+
+
+
+

--- a/Frontend/src/components/FunctionDetail/RationalPointsTable.js
+++ b/Frontend/src/components/FunctionDetail/RationalPointsTable.js
@@ -11,6 +11,7 @@ import { styled } from '@mui/material/styles';
 import { get_rational_periodic_data, get_label, get_graph_metadata } from '../../api/routes';
 import AdjacencyMatrix from '../FunctionDetail/AdjacencyMatrix';
 import Copy from '../FunctionDetail/Copy';
+import HelpBox from '../FunctionDetail/HelpBox';
 
 const ScrollableTableContainer = styled(TableContainer)({
   maxHeight: '400px',
@@ -41,22 +42,18 @@ export default function RationalPointsTable({ data }) {
       get_rational_periodic_data(functionId)
         .then(async response => {
           const rawData = response.data;
-          console.log("Rational Periodic Data:", rawData);
           setRationalData(rawData);
 
           const metaMap = {};
           for (const item of rawData) {
             const graphId = item[4];
-            console.log("Graph ID extracted:", graphId);
             try {
               const metaResponse = await get_graph_metadata(graphId);
-              console.log(`Metadata for graph_id ${graphId}:`, metaResponse.data, Object.keys(metaResponse.data));
               metaMap[graphId] = metaResponse.data;
             } catch (error) {
               console.error(`Error fetching metadata for graph_id ${graphId}:`, error);
             }
           }
-          console.log("Final graphMetaMap:", metaMap);
           setGraphMetaMap(metaMap);
         })
         .catch(error => {
@@ -82,22 +79,44 @@ export default function RationalPointsTable({ data }) {
         <Table size="small" stickyHeader>
           <TableHead>
             <TableRow>
-              <TableCell><b>Field Label</b></TableCell>
-              <TableCell><b>Cardinality</b></TableCell>
-              <TableCell><b>As Directed Graph</b></TableCell>
-              <TableCell><b>Adjacency Matrix</b></TableCell>
-              <TableCell><b>Cycle Lengths</b></TableCell>
-              <TableCell><b>Component Sizes</b></TableCell>
-              <TableCell><b>Rational Preperiodic Points</b></TableCell>
-              <TableCell><b>Longest Tail</b></TableCell>
+              <TableCell>
+                <b>Field Label</b>
+                <HelpBox title="Field Label" description="An identifier representing the field extension the map is defined over, typically in a dot-separated form." />
+              </TableCell>
+              <TableCell>
+                <b>Cardinality</b>
+                <HelpBox title="Cardinality" description="The number of elements in the field over which the function is defined." />
+              </TableCell>
+              <TableCell>
+                <b>As Directed Graph</b>
+                <HelpBox title="As Directed Graph" description="Visual representation of the function as a directed graph showing how elements map under iteration." />
+              </TableCell>
+              <TableCell>
+                <b>Adjacency Matrix</b>
+                <HelpBox title="Adjacency Matrix" description="The matrix representation of the directed graph where each entry indicates an edge between nodes." />
+              </TableCell>
+              <TableCell>
+                <b>Cycle Lengths</b>
+                <HelpBox title="Cycle Lengths" description="Lengths of distinct cycles formed by rational periodic points under iteration." />
+              </TableCell>
+              <TableCell>
+                <b>Component Sizes</b>
+                <HelpBox title="Component Sizes" description="Sizes of connected components in the directed graph formed by the function." />
+              </TableCell>
+              <TableCell>
+                <b>Rational Preperiodic Points</b>
+                <HelpBox title="Rational Preperiodic Points" description="Points defined over the rational field that eventually become periodic under iteration, along with their preperiod lengths." />
+              </TableCell>
+              <TableCell>
+                <b>Longest Tail</b>
+                <HelpBox title="Longest Tail" description="The maximum preperiod length (number of steps before becoming periodic) among all preperiodic points." />
+              </TableCell>
             </TableRow>
           </TableHead>
           <TableBody>
             {rationalData.map((item, index) => {
               const graphId = item[4];
               const meta = graphMetaMap[graphId] || {};
-
-              console.log(`Rendering row ${index} for graphId ${graphId}`, meta);
 
               return (
                 <TableRow key={index}>
@@ -106,14 +125,14 @@ export default function RationalPointsTable({ data }) {
                   <TableCell><Copy edges={formatData("edges")} type={2} /></TableCell>
                   <TableCell>
                     <AdjacencyMatrix modalTitle={"Adjacency Matrix"} edges={formatData("edges")} />
-                    <Copy edges={formatData("edges")} type={1} />
                   </TableCell>
                   <TableCell>{Array.isArray(meta.periodic_cycles) && meta.periodic_cycles.length > 0 ? `[${meta.periodic_cycles.join(', ')}]` : 'N/A'}</TableCell>
                   <TableCell>{Array.isArray(meta.preperiodic_components) && meta.preperiodic_components.length > 0 ? `[${meta.preperiodic_components.join(', ')}]` : 'N/A'}</TableCell>
                   <TableCell>
-                    {item[3].map((point, idx) => (
-                      <div key={idx}>{`(${point[0]}, ${point[1]})`}</div>
-                    ))}
+                    {Array.isArray(item[3]) && item[3].length > 0 ? (item[3].map((point, idx) => (
+                        <div key={idx}>{`(${point[0]}, ${point[1]})`}</div>
+                      ))
+                    ) : ('N/A')}
                   </TableCell>
                   <TableCell>{meta.max_tail !== undefined && meta.max_tail !== null ? meta.max_tail : 'N/A'}</TableCell>
                 </TableRow>

--- a/Frontend/src/components/FunctionDetail/RationalPointsTable.js
+++ b/Frontend/src/components/FunctionDetail/RationalPointsTable.js
@@ -136,33 +136,29 @@ export default function RationalPointsTable({ data }) {
               const meta = graphMetaMap[graphId] || {};
 
               return (
-<TableRow key={index}>
-  <TableCell sx={{ width: '100px', maxWidth: '100px' }}>{item[2]}</TableCell>
-  <TableCell sx={{ width: '60px', maxWidth: '60px', textAlign: 'center' }}>{meta.cardinality !== undefined && meta.cardinality !== null ? meta.cardinality : 'N/A'}</TableCell>
-  <TableCell sx={{ width: '180px', maxWidth: '180px' }}>
-    <Box display="flex" flexDirection="column" alignItems="flex-start" gap={0.5}>
-      <Copy edges={formatData("edges")} type={2} size="small" sx={{ whiteSpace: 'nowrap' }} />
-    </Box>
-  </TableCell>
-  <TableCell sx={{ width: '220px', maxWidth: '220px' }}>
-    <Box display="flex" flexDirection="column" alignItems="flex-start" justifyContent="flex-start" gap={0.5}>
-      <Copy edges={formatData("edges")} type={1} size="small" sx={{ whiteSpace: 'nowrap' }} />
-      <AdjacencyMatrix modalTitle={"Adjacency Matrix"} edges={formatData("edges")} size="small" sx={{ whiteSpace: 'nowrap' }} />
-    </Box>
-  </TableCell>
-  <TableCell sx={{ width: '100px', maxWidth: '100px' }}>{Array.isArray(meta.periodic_cycles) && meta.periodic_cycles.length > 0 ? `[${meta.periodic_cycles.join(', ')}]` : 'N/A'}</TableCell>
-  <TableCell sx={{ width: '120px', maxWidth: '120px' }}>{Array.isArray(meta.preperiodic_components) && meta.preperiodic_components.length > 0 ? `[${meta.preperiodic_components.join(', ')}]` : 'N/A'}</TableCell>
-  <TableCell sx={{ width: '100px', maxWidth: '100px' }}>
-    {Array.isArray(item[3]) && item[3].length > 0 ? (
-      item[3].map((point, idx) => <div key={idx}>{`(${point[0]}, ${point[1]})`}</div>)
-    ) : ('N/A')}
-  </TableCell>
-  <TableCell sx={{ width: '60px', maxWidth: '60px', textAlign: 'center' }}>{meta.max_tail !== undefined && meta.max_tail !== null ? meta.max_tail : 'N/A'}</TableCell>
-</TableRow>
-
-
-
-
+            <TableRow key={index}>
+              <TableCell sx={{ width: '100px', maxWidth: '100px' }}>{item[2]}</TableCell>
+              <TableCell sx={{ width: '60px', maxWidth: '60px', textAlign: 'center' }}>{meta.cardinality !== undefined && meta.cardinality !== null ? meta.cardinality : 'N/A'}</TableCell>
+              <TableCell sx={{ width: '200px', maxWidth: '200px' }}>
+                <Box display="flex" flexDirection="column" alignItems="flex-start" justifyContent="flex-start" gap={0.5} minWidth="200px">
+                  <Copy edges={formatData("edges")} type={2} size="small" sx={{ whiteSpace: 'nowrap' }} />
+                </Box>
+              </TableCell>
+              <TableCell sx={{ width: '200px', maxWidth: '200px' }}>
+                <Box display="flex" flexDirection="column" alignItems="flex-start" justifyContent="flex-start" gap={0.5} minWidth="200px">
+                  <Copy edges={formatData("edges")} type={1} size="small" sx={{ whiteSpace: 'nowrap' }} />
+                  <AdjacencyMatrix modalTitle={"Adjacency Matrix"} edges={formatData("edges")} size="small" sx={{ whiteSpace: 'nowrap' }} />
+                </Box>
+              </TableCell>
+              <TableCell sx={{ width: '100px', maxWidth: '100px' }}>{Array.isArray(meta.periodic_cycles) && meta.periodic_cycles.length > 0 ? `[${meta.periodic_cycles.join(', ')}]` : 'N/A'}</TableCell>
+              <TableCell sx={{ width: '120px', maxWidth: '120px' }}>{Array.isArray(meta.preperiodic_components) && meta.preperiodic_components.length > 0 ? `[${meta.preperiodic_components.join(', ')}]` : 'N/A'}</TableCell>
+              <TableCell sx={{ width: '100px', maxWidth: '100px' }}>
+                {Array.isArray(item[3]) && item[3].length > 0 ? (
+                  item[3].map((point, idx) => <div key={idx}>{`(${point[0]}, ${point[1]})`}</div>)
+                ) : ('N/A')}
+              </TableCell>
+              <TableCell sx={{ width: '60px', maxWidth: '60px', textAlign: 'center' }}>{meta.max_tail !== undefined && meta.max_tail !== null ? meta.max_tail : 'N/A'}</TableCell>
+            </TableRow>
               );
             })}
           </TableBody>


### PR DESCRIPTION
Fixes #218

- What was changed?
This PR modifies both the front end and back end to correctly display rational function metadata in the Function Details > RationalPointsTable. Also the rational points table can now display "N/A" if no data is available, Help pop up buttons were added to help clarify points to users.

- Why was it changed?
The RationalPointsTable was originally displaying incorrect or hard coded values. It was using the data prop (from a higher-level API call) to populate fields like cardinality and cycle lengths, but these values were actually stored in a separate entity (graphs_dim_1_nf) and needed to be indexed by the correct graph_id from the rational periodic data.

- How was it changed?
Frontend:
In RationalPointsTable.js: Added a graphMetaMap state object to store per-graph metadata. Updated the useEffect() to: Fetch rational periodic data, Extract graph_id from item[4], Call get_graph_metadata(graph_id) for each row, and to Store results in graphMetaMap. I also replaced incorrect fields in the table with values from graphMetaMap.
Backend:
In server.py I added a new api route called get_graph_metadata, as well as the function in postgres_connector.py.
