### PR TITLE
Made Minor Fixes for Function Details Display II

### DIFF
--- a/Backend/postgres_connector.py
+++ b/Backend/postgres_connector.py
@@ -72,6 +72,30 @@ class PostgresConnector:
             if cur:
                 cur.close()
 
+    def get_graph_data(self, graph_id):
+        # Get all graph data associated with that graph ID
+        sql = """SELECT * FROM graphs_dim_1_nf
+                WHERE graphs_dim_1_nf.graph_id = %s"""
+        try:
+            with self.connection.cursor() as cur:
+                cur.execute(sql, (graph_id,))
+                row = cur.fetchone()
+
+                if row is None:
+                    return None
+
+                # Get column names and then put the data together as column name: value
+                column_names = [desc[0] for desc in cur.description]
+                result = dict(zip(column_names, row))
+
+        except Exception:
+            self.connection.rollback()
+            result = None
+        finally:
+            if cur:
+                cur.close()
+        return result
+
     def construct_label(self, data):
         return (
             '1.' +

--- a/Backend/postgres_connector.py
+++ b/Backend/postgres_connector.py
@@ -84,7 +84,7 @@ class PostgresConnector:
                 if row is None:
                     return None
 
-                # Get column names and then put the data together as column name: value
+                # Put the data together as column name: value
                 column_names = [desc[0] for desc in cur.description]
                 result = dict(zip(column_names, row))
 

--- a/Backend/server.py
+++ b/Backend/server.py
@@ -80,7 +80,7 @@ def data9():
     graph_id = request.get_json()['graph_id']
     data = connector.get_graph_data(graph_id)
     return jsonify(data)
-  
+
 @app.route('/get_graph_metadata', methods=['POST'])
 def get_graph_metadata():
     graph_id = request.get_json().get('graph_id')

--- a/Backend/server.py
+++ b/Backend/server.py
@@ -75,5 +75,11 @@ def data8():
     label = connector.get_label(function_id)
     return jsonify({'label': label})
 
+@app.route('/get_graph_data', methods=['POST', 'GET'])
+def data9():
+    graph_id = request.get_json()['graph_id']
+    data = connector.get_graph_data(graph_id)
+    return jsonify(data)
+
 if __name__ == '__main__':
     app.run()

--- a/Frontend/src/api/routes.js
+++ b/Frontend/src/api/routes.js
@@ -51,3 +51,9 @@ export const get_label = (functionId) => axios({
     url: "http://127.0.0.1:5000/get_label",
     data: { function_id: functionId }
 });
+
+export const get_graph_data = (graphId) => axios({
+    method: "post",
+    url: "http://127.0.0.1:5000/get_graph_data",
+    data: { graph_id: graphId }
+});

--- a/Frontend/src/components/FunctionDetail/CriticalPointPortraitTable.js
+++ b/Frontend/src/components/FunctionDetail/CriticalPointPortraitTable.js
@@ -8,10 +8,29 @@ import Paper from '@mui/material/Paper';
 import AdjacencyMatrix from '../FunctionDetail/AdjacencyMatrix'
 import Copy from '../FunctionDetail/Copy'
 import HelpBox from '../FunctionDetail/HelpBox'
+import { get_graph_data, get_label } from '../../api/routes';
+import { useEffect, useState } from 'react';
 
 export default function CriticalPointPortraitTable({ data }) {
+  const [graphData, setGraphData] = useState([]);
+  const graphId = data?.graph_id;
+  
+  // Get graph data from backend (additional call)
+  useEffect(() => {
+    if (graphId) {
+      get_graph_data(graphId)
+        .then(response => {
+          console.log("Graph Data:", response.data);
+          setGraphData(response.data);
+        })
+        .catch(error => {
+          console.error("Error fetching graph data:", error);
+        });
+    }
+  }, [graphId]);
+
   const formatData = (key) => {
-    const value = data[key];
+    const value = graphData[key];
   
     if (value === null || value === undefined) {
       return 'N/A';

--- a/Frontend/src/components/FunctionDetail/CriticalPointsTable.js
+++ b/Frontend/src/components/FunctionDetail/CriticalPointsTable.js
@@ -33,7 +33,17 @@ export default function CriticalPointsTable({ data }) {
               <b>Field of Definition</b>
               <HelpBox description="The smallest field containing all of the critical points." title="Field of Definition" />
             </TableCell>
-            <TableCell align="right">{data.cp_field_of_defn || "N/A"}</TableCell>
+            <TableCell align="right">{data.cp_field_of_defn ? (
+                <a
+                  href={`https://www.lmfdb.org/NumberField/${data.cp_field_of_defn}`}
+                  style={{
+                    color: "blue",
+                    textDecoration: "underline"
+                  }}
+                  target="_blank"
+                  rel="noopener noreferrer">
+                    {data.cp_field_of_defn}
+                </a>): ('N/A')}</TableCell>
           </TableRow>
         </TableBody>
       </Table>

--- a/Frontend/src/components/FunctionDetail/ModelsTable.js
+++ b/Frontend/src/components/FunctionDetail/ModelsTable.js
@@ -39,8 +39,18 @@ export function processInput(input) {
 		const exponentX = coeffs.length - 1 - i;
 		const exponentY = i;
 		let monomial = '';
-		if (exponentX > 0) monomial += `x^${exponentX}`;
-		if (exponentY > 0) monomial += `y^${exponentY}`;
+		if (exponentX > 0) {
+      monomial += `x`;
+      if (exponentX > 1) {
+        monomial += `^${exponentX}`;
+      }
+    }
+		if (exponentY > 0) {
+      monomial += `y`;
+      if (exponentX > 1) {
+        monomial += `^${exponentY}`;
+      }
+    }
 		return coefficient === '1' ? monomial : `${coefficient}${monomial}`;
 		})
 		.filter(Boolean)
@@ -141,9 +151,21 @@ export default function ModelsTable({ data }) {
                 <TableCell>{renderExponent(processInput(modelData[0]))}</TableCell>
                 <TableCell>{modelData[1]}</TableCell>
                 <TableCell>{modelData[2]}</TableCell>
-                <TableCell>{data.cp_field_of_defn || 'N/A'}</TableCell>
+                <TableCell>{data.cp_field_of_defn ? (
+                <a
+                  href={`https://www.lmfdb.org/NumberField/${data.cp_field_of_defn}`}
+                  style={{
+                    color: "blue",
+                    textDecoration: "underline"
+                  }}
+                  target="_blank"
+                  rel="noopener noreferrer">
+                    {data.cp_field_of_defn}
+                </a>): ('N/A')}
+                </TableCell>
                 <TableCell>{chebyshevModel}</TableCell>
               </TableRow>
+
             );
           })}
         </TableBody>

--- a/Frontend/src/components/FunctionDetail/RationalPointsTable.js
+++ b/Frontend/src/components/FunctionDetail/RationalPointsTable.js
@@ -78,7 +78,17 @@ export default function RationalPointsTable({ data }) {
           <TableBody>
             {rationalData.map((item, index) => (
               <TableRow key={index}>
-                <TableCell>{item[2]}</TableCell> {/* Field Label */}
+                <TableCell>
+                <a
+                  href={`https://www.lmfdb.org/NumberField/${item[2]}`}
+                  style={{
+                    color: "blue",
+                    textDecoration: "underline"
+                  }}
+                  target="_blank"
+                  rel="noopener noreferrer">
+                    {item[2]}
+                </a></TableCell> {/* Field Label */}
                 <TableCell>{data.cardinality}</TableCell> {/* Cardinality */}
                 <TableCell><Copy edges={formatData("edges")} type={2} /></TableCell> {/* As Directed Graph */}
                 <TableCell>

--- a/Frontend/src/components/FunctionDetail/RationalTwistsTable.js
+++ b/Frontend/src/components/FunctionDetail/RationalTwistsTable.js
@@ -21,7 +21,7 @@ export default function RationalTwistsTable({ data }) {
           </TableRow>
           {/* Data Row */}
           <TableRow>
-            <TableCell>{data.modelLabel}</TableCell>
+            <TableCell>{data.function_id}</TableCell>
             <TableCell>
               {data.rational_twists && data.rational_twists.length > 0 ? (
                 data.rational_twists.map((id, index) => (

--- a/Frontend/src/components/FunctionDetail/RationalTwistsTable.js
+++ b/Frontend/src/components/FunctionDetail/RationalTwistsTable.js
@@ -47,7 +47,7 @@ export default function RationalTwistsTable({ data }) {
               {data.rational_twists && data.rational_twists.length > 0 ? (
                 data.rational_twists.map((id, index) => (
                   <React.Fragment key={id}>
-                    <a href={`http://localhost:3000/system/${id}/`} target="_blank" rel="noopener noreferrer">
+                    <a href={`${window.location.href.split('/')[0]}/system/${id}/`} target="_blank" rel="noopener noreferrer">
                       {<ModelLabel id={id} />}
                     </a>
                     <br></br>

--- a/Frontend/src/components/FunctionDetail/RationalTwistsTable.js
+++ b/Frontend/src/components/FunctionDetail/RationalTwistsTable.js
@@ -5,9 +5,30 @@ import TableCell from '@mui/material/TableCell';
 import TableContainer from '@mui/material/TableContainer';
 import TableRow from '@mui/material/TableRow';
 import Paper from '@mui/material/Paper';
+import { useEffect, useState } from 'react';
+import { get_label } from '../../api/routes';
 
 export default function RationalTwistsTable({ data }) {
   console.log(data);
+
+  const ModelLabel = ({ id }) => {
+    const [modelLabel, setModelLabel] = useState(null);
+  
+    // Once the backend data gets received,
+    // then update the text with the label
+    useEffect(() => {
+      get_label(id)
+      .then(response => {
+        setModelLabel(response.data.label);
+      })
+      .catch(error => {
+        console.error("Error fetching label:", error);
+      });
+    }, [id]);
+  
+    // While the label is being retrieved, show function ID in the meantime
+    return <>{modelLabel || "Function ID: " + id}</>;
+  };
 
   return (
     <TableContainer component={Paper} className="table-component">
@@ -21,15 +42,15 @@ export default function RationalTwistsTable({ data }) {
           </TableRow>
           {/* Data Row */}
           <TableRow>
-            <TableCell>{data.function_id}</TableCell>
+            <TableCell>{data.modelLabel}</TableCell>
             <TableCell>
               {data.rational_twists && data.rational_twists.length > 0 ? (
                 data.rational_twists.map((id, index) => (
                   <React.Fragment key={id}>
                     <a href={`http://localhost:3000/system/${id}/`} target="_blank" rel="noopener noreferrer">
-                      {id}
+                      {<ModelLabel id={id} />}
                     </a>
-                    {index < data.rational_twists.length - 1 && ", "}
+                    <br></br>
                   </React.Fragment>
                 ))
               ) : "None"}


### PR DESCRIPTION
Fixes #219 

**What was changed?**

The Critical Points Table was updated to show data from the graph data table. This required multiple changes in the backend.

I then updated the Rational Twists Display so the model labels are now shown for each Rational Twists system. This required retrieving additional data from the database, constructing the model label for each system, and then updating the UI after the page has been loaded.

Finally, I had the polynomials in the models table no longer show 1 as an exponent. I also added links to the LMFDB for the remaining instances of "Field Label" and "Field of Definition" in the page.

**Why was it changed?**

This directly fixes Issue 219 to make these UI updates to make the website more accurate and functional.

**How was it changed?**

Updating the Critical Points Table to display the graph data was the hardest part as there was then no way to grab just graph data from the database. New functions and connections were needed to grab additional data.

1. First, I added a function `get_graph_data()` in the `postgres_connector.py` in order to retrieve the graph data associated with a graph id from the database.

2. I next added a Flask route (`data9()`) in `server.py` so the Flask backend knows to call `get_graph_data()` when the backend gets requested for graph data via URL.

3. Then, I added a route (`get_graph_data`) in the `routes.js` file so Axios can connect the React frontend to the Flask backend.

4. The `CriticalPointPotraitTable.js` file was updated to process this additional data and to request for the additional data in the first place.

The Rational Twists Display Table was modified so the model label is shown for each Rational Twists system.
1. A custom tag `<ModelLabel>` was used to allow for manipulation after the page is loaded.
2. A React `useEffect` must be used so the UI can work while data is still being retrieved from the Backend.
3. When `useEffect` is called, it calls the `get_label(id)` function from the backend to get the model label for the corresponding ID (which is from the Rational Twists data).
4. While the data is being retrieved, a placeholder text (the function ID) is shown to the user.
5. Once the data is retrieved, it is returned and the custom tag is updated with the model label.

When the exponent string was being created in the `ModelsTable.js` file, I modified it so that it does not add the exponent if the exponent is equal to 1. Links (`<a>`) were added to the `CriticalPointsTable.js`, `ModelsTable.js`, and `RationalPointsTable.js` files, and matched the style of the existing links.

**Screenshots that show the changes (if applicable):**

![rational twists table](https://github.com/user-attachments/assets/f0b18122-1285-442d-9358-f68d1c9c25d4)
Updated Rational Twists Table - You can see that the model labels are shown for each Rational Twists system.

![critical points table](https://github.com/user-attachments/assets/d7b1fbbb-9cd8-4a7e-b1ab-b90854c1673d)
The Critical Points Table was updated to show data from the graph data table.

![git pic](https://github.com/user-attachments/assets/539b788e-06ba-4338-af1c-fc6b3badaa4e)
Here, you can see the exponents do not show if it is equal to 1, and the Field of Definition have direct links now.