### PR TITLE
changes to some design elements making it look better

### DIFF
--- a/Frontend/src/components/FunctionDetail/FunctionAttributes.js
+++ b/Frontend/src/components/FunctionDetail/FunctionAttributes.js
@@ -108,27 +108,56 @@ export default function FunctionAttributes({ data }) {
       <h3>Function Attributes</h3>
       <h6>Attributes identifying the type of conjugacy class.</h6>
       <Table aria-label="function attributes table">
-        <TableBody>
-          {/* Row for field labels */}
-          <TableRow>
-            <TableCell><b>Is Newton Function</b><HelpBox description="True if this conjugacy class represents a function from Newton’s method: f(z) = z- F(z)/F'(z)" title="Is Newton Function" /></TableCell>
-            <TableCell><b>Is Polynomial</b><HelpBox description="True if this conjugacy class represents a polynomial map; i.e., if it has a totally ramified fixed point." title="Is Polynomial" /></TableCell>
-            <TableCell><b>Is Postcritically Finite (PCF)</b><HelpBox description="True if every critical point is preperiodic." title="Is Postcritically Finite (PCF)" /></TableCell>
-            <TableCell><b>Is Lattès Function</b><HelpBox description="True if this conjugacy class represents a Lattes function. Note that the label for Lattes maps contains the LMFDB label of the elliptic curve rather than the sigma invariants." title="Is Lattès Function" /></TableCell>
-            <TableCell><b>Associated Polynomial</b></TableCell>
-            <TableCell><b>Automorphism Cardinality</b><HelpBox description="Shows how many elements are in the set." title="Automorphism Cardinality" /></TableCell>
-          </TableRow>
-          {/* Row for values */}
-          <TableRow>
-            <TableCell>{isNewtonFunction}</TableCell>
-            <TableCell>{String(data.is_polynomial)}</TableCell>
-            <TableCell>{String(data.is_pcf)}</TableCell>
-            {/* <TableCell>{String(data.is_lattes)}</TableCell> */}
-            <TableCell>{String(data.is_lattes)} {lattesLink}</TableCell>
-            <TableCell>{data.is_newton ? newtonPolynomial : ""}</TableCell>
-            <TableCell>{data.automorphism_group_cardinality !== undefined ? data.automorphism_group_cardinality: "N/A"}</TableCell>
-          </TableRow>
-        </TableBody>
+      <TableBody>
+        {/* Row for field labels */}
+        <TableRow>
+          <TableCell>
+            <b>Is Newton Function</b>
+            <HelpBox description="True if this conjugacy class represents a function from Newton’s method: f(z) = z- F(z)/F'(z)" title="Is Newton Function" />
+          </TableCell>
+          {data.is_newton && (
+            <TableCell>
+              <b>Newton Polynomial</b>
+            </TableCell>
+          )}
+          <TableCell>
+            <b>Is Polynomial</b>
+            <HelpBox description="True if this conjugacy class represents a polynomial map; i.e., if it has a totally ramified fixed point." title="Is Polynomial" />
+          </TableCell>
+          <TableCell>
+            <b>Is Postcritically Finite (PCF)</b>
+            <HelpBox description="True if every critical point is preperiodic." title="Is Postcritically Finite (PCF)" />
+          </TableCell>
+          <TableCell>
+            <b>Is Lattès Function</b>
+            <HelpBox description="True if this conjugacy class represents a Lattes function. Note that the label for Lattes maps contains the LMFDB label of the elliptic curve rather than the sigma invariants." title="Is Lattès Function" />
+          </TableCell>
+          <TableCell>
+            <b>Is Chebyshev</b>
+          </TableCell>
+          {data.is_chebyshev && (
+            <TableCell>
+              <b>Chebyshev Model</b>
+            </TableCell>
+          )}
+          <TableCell>
+            <b>Automorphism Cardinality</b>
+            <HelpBox description="Shows how many elements are in the set." title="Automorphism Cardinality" />
+          </TableCell>
+        </TableRow>
+
+        {/* Row for values */}
+        <TableRow>
+          <TableCell>{isNewtonFunction}</TableCell>
+          {data.is_newton && <TableCell>{newtonPolynomial}</TableCell>}
+          <TableCell>{String(data.is_polynomial)}</TableCell>
+          <TableCell>{String(data.is_pcf)}</TableCell>
+          <TableCell>{String(data.is_lattes)} {lattesLink}</TableCell>
+          <TableCell>{String(data.is_chebyshev)}</TableCell>
+          {data.is_chebyshev && <TableCell>{chebyshevModel}</TableCell>}
+          <TableCell>{data.automorphism_group_cardinality !== undefined ? data.automorphism_group_cardinality : "N/A"}</TableCell>
+        </TableRow>
+      </TableBody>
       </Table>
     </TableContainer>
   );

--- a/Frontend/src/components/FunctionDetail/FunctionAttributes.js
+++ b/Frontend/src/components/FunctionDetail/FunctionAttributes.js
@@ -115,7 +115,7 @@ export default function FunctionAttributes({ data }) {
             <TableCell><b>Is Polynomial</b><HelpBox description="True if this conjugacy class represents a polynomial map; i.e., if it has a totally ramified fixed point." title="Is Polynomial" /></TableCell>
             <TableCell><b>Is Postcritically Finite (PCF)</b><HelpBox description="True if every critical point is preperiodic." title="Is Postcritically Finite (PCF)" /></TableCell>
             <TableCell><b>Is Lattès Function</b><HelpBox description="True if this conjugacy class represents a Lattes function. Note that the label for Lattes maps contains the LMFDB label of the elliptic curve rather than the sigma invariants." title="Is Lattès Function" /></TableCell>
-            {data.is_newton && <TableCell><b>Associated Polynomial</b></TableCell>}
+            <TableCell><b>Associated Polynomial</b></TableCell>
             <TableCell><b>Automorphism Cardinality</b><HelpBox description="Shows how many elements are in the set." title="Automorphism Cardinality" /></TableCell>
           </TableRow>
           {/* Row for values */}
@@ -125,8 +125,7 @@ export default function FunctionAttributes({ data }) {
             <TableCell>{String(data.is_pcf)}</TableCell>
             {/* <TableCell>{String(data.is_lattes)}</TableCell> */}
             <TableCell>{String(data.is_lattes)} {lattesLink}</TableCell>
-            <TableCell>{String(data.is_chebyshev)}</TableCell>
-            {data.is_newton && <TableCell>{newtonPolynomial}</TableCell>}
+            <TableCell>{data.is_newton ? newtonPolynomial : ""}</TableCell>
             <TableCell>{data.automorphism_group_cardinality !== undefined ? data.automorphism_group_cardinality: "N/A"}</TableCell>
           </TableRow>
         </TableBody>

--- a/Frontend/src/pages/ExploreSystems.js
+++ b/Frontend/src/pages/ExploreSystems.js
@@ -378,6 +378,15 @@ function ExploreSystems() {
         marginRight: "12px",
     };
 
+    const smallStyles = {
+        inlineHelpLabel: {
+          fontSize: "0.9rem",
+          whiteSpace: "nowrap",
+          display: "inline-block",
+          verticalAlign: "middle"
+        }
+    };
+
     return (
         <>
             <div>
@@ -834,11 +843,11 @@ function ExploreSystems() {
             {filtersApplied && <ActiveFiltersBanner filters={filtersApplied} />}
                         <PaginatedDataTable
                             labels={[
-                                <>Label<HelpBox description="A unique identifier of the form N.S1.S2.M where N is the dimension of the domain, S1 is a hash of the sigma invariants of the fixed points, S2 is a hash of the sigma invariants of the points of period 2, and M is an ordinal to ensure uniqueness." title="Label" /></>,
-                                <>Domain<HelpBox description="The ambient domain of the map; a projective space" title="Domain" /></>,
-                                <>Degree<HelpBox description="Degree of the homogeneous polynomials of a representative of this map." title="Degree" /></>,
-                                <>Polynomial<HelpBox description="Representative polynomials in the selected standard model." title="Polynomials" /></>,
-                                <>Field<HelpBox description="The smallest field containing all coefficients of the standard representative polynomials." title="Field" /></>
+                                <><span style={smallStyles.inlineHelpLabel}>Label</span><HelpBox description="A unique identifier of the form N.S1.S2.M where N is the dimension of the domain, S1 is a hash of the sigma invariants of the fixed points, S2 is a hash of the sigma invariants of the points of period 2, and M is an ordinal to ensure uniqueness." title="Label" /></>,
+                                <><span style={smallStyles.inlineHelpLabel}>Domain</span><HelpBox description="The ambient domain of the map; a projective space" title="Domain" /></>,
+                                <><span style={smallStyles.inlineHelpLabel}>Degree</span><HelpBox description="Degree of the homogeneous polynomials of a representative of this map." title="Degree" /></>,
+                                <><span style={smallStyles.inlineHelpLabel}>Polynomial</span><HelpBox description="Representative polynomials in the selected standard model." title="Polynomials" /></>,
+                                <><span style={smallStyles.inlineHelpLabel}>Field</span><HelpBox description="The smallest field containing all coefficients of the standard representative polynomials." title="Field" /></>
                             ]}
                             data={
                                 systems === null


### PR DESCRIPTION
What was changed?

    Updated the FunctionAttributes component to ensure the <Table> renders with a consistent number of columns between the header and data rows.

    Adjusted font size for the labels "domain", "degree", and "field" in the paginatedDataTable section (line 835 of ExploreSystems.js) to prevent layout wrapping of the associated helpbox components.

Why was it changed?

    The table previously rendered an extra, unlabeled column due to a mismatch in the number of <TableCell> elements between the header and body rows, caused by conditional rendering of the "Associated Polynomial" field. This led to layout and alignment issues.

    The helpbox tooltips for "domain", "degree", and "field" were wrapping to the next line because the font size of the label text caused overflow. This reduced readability and layout cohesion.

How was it changed?

    Made the "Associated Polynomial" column always present in both header and data rows, with conditional logic applied only to its content rather than its rendering.

    Added inline styles (or used a reusable style object) to reduce the font size of the "domain", "degree", and "field" labels, ensuring that their corresponding helpboxes now appear inline without line breaks.