### PR TITLE
Fix families pages for dict-based backend responses

### DIFF
--- a/Frontend/src/api/routes.js
+++ b/Frontend/src/api/routes.js
@@ -21,7 +21,7 @@ export const get_families = () => api.get("/get_all_families");
 export const get_family = (familyId) => api.post("/get_family", { id: familyId });
 
 // dreyes: used to filter families based on the filters selected in the UI
-export const get_filtered_families = (filters) => api.post("/get_filtered_familes", filters);
+export const get_filtered_families = (filters) => api.post("/get_filtered_families", filters);
 
 export const get_rational_periodic_data = (functionId) => 
     api.post("/get_rational_periodic_data", { function_id: functionId });

--- a/Frontend/src/pages/ExploreSystems.js
+++ b/Frontend/src/pages/ExploreSystems.js
@@ -159,8 +159,8 @@ function ExploreSystems() {
         try {
             const result = await get_families()
             const autocompleteOptions = result.data.map((family) => ({
-                id: family[0], // Use the first element as id
-                name: family[1], // Use the second element as label
+                id: Array.isArray(family) ? family[0] : family.family_id,
+                name: Array.isArray(family) ? family[1] : family.name,
             }));
             setFamilies(autocompleteOptions)
             setOptionsLoading(false)

--- a/Frontend/src/pages/Families.js
+++ b/Frontend/src/pages/Families.js
@@ -20,6 +20,22 @@ function Families() {
             console.log(error)
         }
      }
+
+    const parseFamilyRecord = (family) => {
+        if (Array.isArray(family)) {
+            return {
+                id: family[0],
+                name: family[1],
+                degree: family[2],
+            };
+        }
+
+        return {
+            id: family.family_id,
+            name: family.name,
+            degree: family.degree,
+        };
+    };
      
     useEffect(() => {
         fetchFamilies()
@@ -49,9 +65,11 @@ function Families() {
                             data={
                                 families === null
                                     ? []
-                                    : families.map((x) => [
+                                    : families.map((x) => {
+                                          const family = parseFamilyRecord(x);
+                                          return [
                                           <button
-                                              onClick={() => handleLinkClick(x[0])}
+                                              onClick={() => handleLinkClick(family.id)}
                                               style={{
                                                   border:"None",
                                                   color: "red",
@@ -60,11 +78,11 @@ function Families() {
                                 
                                               }}
                                           >
-                                              {x[0]}
+                                              {family.id}
                                           </button>,
-                                          x[1],
-                                          x[2],
-                                      ])
+                                          family.name,
+                                          family.degree,
+                                      ]})
                             }
                             itemsPerPage={pagesPer}
                             currentPage={1}

--- a/Frontend/src/pages/FilteredFamilies.js
+++ b/Frontend/src/pages/FilteredFamilies.js
@@ -165,6 +165,26 @@ function FilteredFamilies() {
         return `[${left} : ${right}]`;
     };
 
+    const parseFamilyRecord = (family) => {
+        if (Array.isArray(family)) {
+            return {
+                id: family[0],
+                name: family[1],
+                degree: family[2],
+                modelCoeffs: family[4],
+                baseFieldLabel: family[6]
+            };
+        }
+
+        return {
+            id: family.family_id,
+            name: family.name,
+            degree: family.degree,
+            modelCoeffs: family.model_coeffs,
+            baseFieldLabel: family.base_field_label
+        };
+    };
+
     return (
         <>
             <div className="results-container" container>
@@ -356,9 +376,11 @@ function FilteredFamilies() {
                         data={
                             families === null
                                 ? []
-                                : families.map((x) => [
+                                : families.map((x) => {
+                                    const family = parseFamilyRecord(x);
+                                    return [
                                     <button
-                                        onClick={() => handleLinkClick(x[0])}
+                                        onClick={() => handleLinkClick(family.id)}
                                         style={{
                                             border: "None",
                                             color: "red",
@@ -366,16 +388,16 @@ function FilteredFamilies() {
                                             cursor: "pointer"
                                         }}
                                     >
-                                        {x[0]}
+                                        {family.id}
                                     </button>,
-                                    x[1],
-                                    x[2],
+                                    family.name,
+                                    family.degree,
                                     <>
                                         P<sup>1</sup> {String.fromCharCode(8594)} P<sup>1</sup>
                                     </>,
-                                    formatFamilyPolynomial(x[4], x[2]),
-                                    x[6]
-                                ])
+                                    formatFamilyPolynomial(family.modelCoeffs, family.degree),
+                                    family.baseFieldLabel
+                                ]})
                         }
                         itemsPerPage={pagesPer}
                         currentPage={page}


### PR DESCRIPTION
### Motivation

- Backend responses for families were changed from positional arrays to objects/dicts and a frontend route had a typo, which caused the families pages and family-related autocomplete to break.

### Description

- Corrected the frontend API client route from `/get_filtered_familes` to `/get_filtered_families` in `Frontend/src/api/routes.js`.
- Added `parseFamilyRecord` helpers to `Frontend/src/pages/Families.js` and `Frontend/src/pages/FilteredFamilies.js` to normalize records returned either as arrays or as objects with named fields, and updated table rendering to use the normalized fields.
- Updated `Frontend/src/pages/ExploreSystems.js` to build family autocomplete options from either array-shaped or object-shaped family records.
- Adjusted polynomial and field rendering inputs in `FilteredFamilies` to use the parsed object fields (`model_coeffs` / `modelCoeffs` and `base_field_label` / `baseFieldLabel`).

### Testing

- Ran `npm --prefix Frontend run build` which completed successfully and produced a production build with warnings.
- Ran `npm --prefix Frontend run lint` which failed due to many pre-existing repository-wide lint issues unrelated to these specific changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7d3de5bd883239d1a47577106e593)