### PR TITLE
Fix backend lint errors in PostgresConnector and statistics endpoint

### DIFF
--- a/Backend/postgres_connector.py
+++ b/Backend/postgres_connector.py
@@ -22,11 +22,12 @@ class PostgresConnector:
     """
 
     def __init__(self):
+        self.connection = None
         self.connect()
 
     def connect(self):
         config = load_config()
-        if not hasattr(self, 'connection') or self.connection is None or self.connection.closed:
+        if self.connection is None or self.connection.closed:
             try:
                 self.connection = psycopg2.connect(**config)
                 print('Connected to the PostgreSQL server.')
@@ -73,7 +74,8 @@ class PostgresConnector:
                     result = dicts[0] if dicts else None
 
         except Exception as e:
-            if self.connection: self.connection.rollback()
+            if self.connection:
+                self.connection.rollback()
             raise e
             
         finally:
@@ -182,8 +184,10 @@ class PostgresConnector:
                 if d not in mon_dict:
                     mon = []
                     for i in range(d+1):
-                        if i == 0: mon.append('x^'+str(d))
-                        elif i == d: mon.append('y^'+str(d))
+                        if i == 0:
+                            mon.append('x^'+str(d))
+                        elif i == d:
+                            mon.append('y^'+str(d))
                         else:
                             term = 'x' if (d-i) == 1 else 'x^'+str(d-i)
                             term += 'y' if i == 1 else 'y^'+str(i)
@@ -200,11 +204,15 @@ class PostgresConnector:
                         if val != '0':
                             if val[0] != '-' and not first_term:
                                 poly += '+'
-                            if val == '1': poly += mon[i]
-                            elif val == '-1': poly += '-' + mon[i]
-                            else: poly += val + mon[i]
+                            if val == '1':
+                                poly += mon[i]
+                            elif val == '-1':
+                                poly += '-' + mon[i]
+                            else:
+                                poly += val + mon[i]
                             first_term = False
-                    if j == 0: poly += ' : '
+                    if j == 0:
+                        poly += ' : '
                 poly += ']'
                 
                 label = self.construct_label(row)

--- a/Backend/server.py
+++ b/Backend/server.py
@@ -69,7 +69,8 @@ def data4():
 @app.route('/get_statistics', methods=['POST', 'GET'])
 def data5():
     filters = request.get_json()
-    data = connector.get_statistics(filters)
+    where_sql, params = connector.build_where_text(filters)
+    data = connector.get_statistics(where_sql, params)
     return jsonify(data)
 
 @app.route('/get_all_families', methods=['POST', 'GET'])


### PR DESCRIPTION
### Motivation
- Resolve linting errors: `C0321` (multiple-statements), `E0203` (access-member-before-definition), and `E1120` (missing parameter) reported for backend modules.

### Description
- Initialize `PostgresConnector.connection` to `None` in `__init__` and simplify the `connect()` guard to avoid accessing the member before definition and ensure a clear connection check.
- Expand single-line conditionals and inline statements in `Backend/postgres_connector.py` (rollback handling, polynomial monomial construction, and string concatenation branches) into multi-line blocks to satisfy `C0321` style rules.
- Update the `/get_statistics` route in `Backend/server.py` to call `connector.build_where_text(filters)` and pass both `where_sql` and `params` into `connector.get_statistics()` to supply the required arguments.

### Testing
- Successfully compiled the modified modules with `python -m py_compile Backend/postgres_connector.py Backend/server.py`.
- Attempted to run `pylint Backend/postgres_connector.py Backend/server.py` but `pylint` is not available in the execution environment, so lint checks could not be re-run here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7e4fc178083239a89c7dab7d4a090)